### PR TITLE
Twisted: Normalize documentation commentary.

### DIFF
--- a/src/python/dns_resolv/controller_helper.py
+++ b/src/python/dns_resolv/controller_helper.py
@@ -12,8 +12,9 @@
 # (See the LICENSE file at the top of the source tree.)
 #
 
-## The helper for the controller class and related ones.
 class ControllerHelper:
+    """The helper for the controller class and related ones."""
+
     # Helper constants.
     _EXIT_FAILURE     =    1 #    Failing exit status.
     _EXIT_SUCCESS     =    0 # Successful exit status.
@@ -79,12 +80,13 @@ class ControllerHelper:
     ## Constant: The default hostname to look up for.
     _DEF_HOSTNAME = "openbsd.org"
 
-    ##
-    # Adds headers to the response.
-    #
-    # @param req The incoming HTTP request object.
-    #
     def add_response_headers(self, req):
+        """Adds headers to the response.
+
+        Args:
+            req: The incoming HTTP request object.
+        """
+
         req.setHeader(self._HDR_CONTENT_TYPE_N,  self._HDR_CONTENT_TYPE_V )
         req.setHeader(self._HDR_CACHE_CONTROL_N, self._HDR_CACHE_CONTROL_V)
         req.setHeader(self._HDR_EXPIRES_N,       self._HDR_EXPIRES_V      )
@@ -107,8 +109,9 @@ class ControllerHelper:
         exec("while (True):\n\tprint('=', end=self._EMPTY_STRING)\n\ti -= 1\n"
            + "\tif (not i):\n\t\tbreak\nprint()")
 
-    ## Default constructor.
     def __init__(self):
+        """Default constructor."""
+
         self = []
 
         return None

--- a/src/python/dns_resolv/dns_lookup_controller.py
+++ b/src/python/dns_resolv/dns_lookup_controller.py
@@ -14,19 +14,22 @@
 
 from dns.resolver import Resolver, NoAnswer
 
-## The controller class of the daemon.
 class DnsLookupController:
-    ##
-    # Performs DNS lookup action for the given hostname,
-    # i.e. (in this case) IP address retrieval by hostname.
-    #
-    # @param hostname The effective hostname to look up for.
-    # @param aux      The controller helper object instance.
-    #
-    # @return The IP address retrieved for the host analyzed
-    #         and the IP version (family) used to look up in DNS.
-    #
+    """The controller class of the daemon."""
+
     def dns_lookup(self, hostname, aux):
+        """Performs DNS lookup action for the given hostname,
+        i.e. (in this case) IP address retrieval by hostname.
+
+        Args:
+            hostname: The effective hostname to look up for.
+            aux:      The controller helper object instance.
+
+        Returns:
+            The IP address retrieved for the host analyzed
+            and the IP version (family) used to look up in DNS.
+        """
+
         resolver = Resolver()
 
         # If the host doesn't have the A record (IPv4),
@@ -43,8 +46,9 @@ class DnsLookupController:
 
         return (addr, ver)
 
-    ## Default constructor.
     def __init__(self):
+        """Default constructor."""
+
         self = []
 
         return None

--- a/src/python/dnsresolvd
+++ b/src/python/dnsresolvd
@@ -95,8 +95,6 @@ def main(argc, argv):
     except Exception as e:
         ret = aux._EXIT_FAILURE
 
-        print(e)
-
         if (not re.search(aux._ERR_ADDR_ALREADY_IN_USE, str(e))):
             print(daemon_name + aux._ERR_CANNOT_START_SERVER
                               + aux._ERR_SRV_PORT_IS_IN_USE

--- a/src/python/dnsresolvd
+++ b/src/python/dnsresolvd
@@ -19,8 +19,17 @@ import re
 from dns_resolv.controller_helper import ControllerHelper
 from dnsresolvd                   import DnsResolvd
 
-## The daemon main function.
 def main(argc, argv):
+    """The daemon main function.
+
+    Args:
+        argc: The number of command-line arguments.
+        argv: The list   of command-line arguments.
+
+    Returns:
+        The exit code indicating the daemon overall execution status.
+    """
+
     # Instantiating the controller helper class.
     aux = ControllerHelper()
 

--- a/src/python/dnsresolvd.py
+++ b/src/python/dnsresolvd.py
@@ -19,38 +19,45 @@ from twisted.web.server         import Site
 
 from dns_resolv.dns_lookup_controller import DnsLookupController
 
-## The main class of the daemon.
 class DnsResolvd:
-    ##
-    # Starts up the daemon.
-    #
-    # @param port_number The server port number to listen on.
-    # @param aux         The controller helper object instance.
-    #
-    # @return The server exit code when interrupted.
-    #
+    """The main class of the daemon."""
+
     def startup(self, port_number, aux):
+        """Starts up the daemon.
+
+        Args:
+            port_number: The server port number to listen on.
+            aux:         The controller helper object instance.
+
+        Returns:
+            The server exit code when interrupted.
+        """
+
         ret = aux._EXIT_SUCCESS
 
-        ##
-        # The server class of the daemon.
-        # Used by Twisted engine to run an event loop.
-        #
-        # @extends Resource The Twisted web-accessible resource class.
-        #
         class Daemon(Resource):
+            """The server class of the daemon.
+            Used by Twisted engine to run an event loop.
+
+            Extends:
+                Resource: The Twisted web-accessible resource class.
+            """
+
             isLeaf = True
 
-            ##
-            # Renders the HTTP response based on the incoming HTTP request.
-            # It also calls the method to perform DNS lookup for a hostname
-            # passed in the HTTP request.
-            #
-            # @param req The incoming HTTP request object.
-            #
-            # @return The HTTP response has to be rendered.
-            #
             def render_GET(self, req):
+                """Renders the HTTP response based on the incoming HTTP
+                request.
+                It also calls the method to perform DNS lookup for a hostname
+                passed in the HTTP request.
+
+                Args:
+                    req: The incoming HTTP request object.
+
+                Returns:
+                    The HTTP response has to be rendered.
+                """
+
                 query = req.args
                 h     = b"h"
 
@@ -115,8 +122,9 @@ class DnsResolvd:
 
         return ret
 
-    ## Default constructor.
     def __init__(self):
+        """Default constructor."""
+
         self = []
 
         return None


### PR DESCRIPTION
* Replacing Perl 5 **autopod-stylish** documentation comments with their Python **docstring** equivalents.
* Getting rid of debug print in the start script.