### PR TITLE
Mojo: Produce JSON output by default.

### DIFF
--- a/src/perl/dnsresolvd
+++ b/src/perl/dnsresolvd
@@ -64,11 +64,13 @@ use DnsResolvd::ControllerHelper
 use constant DMN_CLASS_NAME => "DnsResolvd";
 
 # Constants: Server start parameters.
-use constant DMN_DAEMON_CMD  => "daemon";
-use constant DMN_LISTEN_OPT  => "-l";
-use constant DMN_OP_MOD_OPT  => "-m";
-use constant DMN_LISTEN_HTTP => "http://*:";
-use constant DMN_OP_MOD_PROD => "production";
+use constant {
+    DMN_DAEMON_CMD  => "daemon",
+    DMN_LISTEN_OPT  => "-l",
+    DMN_OP_MOD_OPT  => "-m",
+    DMN_LISTEN_HTTP => "http://*:",
+    DMN_OP_MOD_PROD => "production",
+};
 
 # Helper function. Makes final buffer cleanups, closes streams, etc.
 sub _cleanups_fixate {

--- a/src/perl/dnsresolvd
+++ b/src/perl/dnsresolvd
@@ -29,9 +29,11 @@ use Mojolicious::Commands;
 use DnsResolvd::ControllerHelper
     "_EXIT_FAILURE",
     "_EXIT_SUCCESS",
+    "_EMPTY_STRING",
     "_ONE_SPACE_STRING",
     "_COMMA_SPACE_SEP",
     "_NEW_LINE",
+    "_PRINT_BANNER_OPT",
 # -----------------------------------------------------------------------------
     "_ERR_PORT_MUST_BE_POSITIVE_INT",
     "_ERR_CANNOT_START_SERVER",
@@ -39,8 +41,8 @@ use DnsResolvd::ControllerHelper
     "_ERR_SRV_PORT_IS_IN_USE",
     "_ERR_ADDR_ALREADY_IN_USE",
 # -----------------------------------------------------------------------------
-    "_ERR_MUST_BE_THE_ONLY_ARG_1",
-    "_ERR_MUST_BE_THE_ONLY_ARG_2",
+    "_ERR_MUST_BE_ONE_TWO_ARGS_1",
+    "_ERR_MUST_BE_ONE_TWO_ARGS_2",
 # -----------------------------------------------------------------------------
     "_MSG_USAGE_TEMPLATE_1",
     "_MSG_USAGE_TEMPLATE_2",
@@ -80,32 +82,40 @@ my $argc        = @ARGV;
 my $daemon_name = $0;
 my $port_number = $ARGV[0];
 
+my $print_banner_opt = _EMPTY_STRING;
+
+if ($argc > 1) {
+    $print_banner_opt = $ARGV[1];
+}
+
 # Opening the system logger.
 openlog($daemon_name, "pid", Sys::Syslog::LOG_DAEMON);
 
 # Instantiating the controller helper class.
 my $aux = DnsResolvd::ControllerHelper->new();
 
-$aux->_separator_draw(_DMN_DESCRIPTION);
+if ($print_banner_opt eq _PRINT_BANNER_OPT) {
+    $aux->_separator_draw(_DMN_DESCRIPTION);
 
-say(_DMN_NAME         . _COMMA_SPACE_SEP  . _DMN_VERSION_S__
-  . _ONE_SPACE_STRING . _DMN_VERSION      . _NEW_LINE
-  . _DMN_DESCRIPTION                      . _NEW_LINE
-  . _DMN_COPYRIGHT__  . _ONE_SPACE_STRING . _DMN_AUTHOR);
+    say(_DMN_NAME         . _COMMA_SPACE_SEP  . _DMN_VERSION_S__
+      . _ONE_SPACE_STRING . _DMN_VERSION      . _NEW_LINE
+      . _DMN_DESCRIPTION                      . _NEW_LINE
+      . _DMN_COPYRIGHT__  . _ONE_SPACE_STRING . _DMN_AUTHOR);
 
-$aux->_separator_draw(_DMN_DESCRIPTION);
+    $aux->_separator_draw(_DMN_DESCRIPTION);
+}
 
 # Checking for args presence.
-if ($argc != 1) {
+if ($argc == 0) {
     $ret = _EXIT_FAILURE;
 
-    say($daemon_name . _ERR_MUST_BE_THE_ONLY_ARG_1
-             . $argc . _ERR_MUST_BE_THE_ONLY_ARG_2
+    say($daemon_name . _ERR_MUST_BE_ONE_TWO_ARGS_1
+             . $argc . _ERR_MUST_BE_ONE_TWO_ARGS_2
                      . _NEW_LINE);
 
     syslog(Sys::Syslog::LOG_ERR,
-        $daemon_name . _ERR_MUST_BE_THE_ONLY_ARG_1
-             . $argc . _ERR_MUST_BE_THE_ONLY_ARG_2
+        $daemon_name . _ERR_MUST_BE_ONE_TWO_ARGS_1
+             . $argc . _ERR_MUST_BE_ONE_TWO_ARGS_2
                      . _NEW_LINE);
 
     say(_MSG_USAGE_TEMPLATE_1 . $daemon_name

--- a/src/perl/lib/DnsResolvd.pm
+++ b/src/perl/lib/DnsResolvd.pm
@@ -14,11 +14,6 @@
 
 package DnsResolvd;
 
-use strict;
-use warnings;
-use utf8;
-use v5.10;
-
 use Mojo::Base "Mojolicious";
 
 ## Constant: The root route to make GET requests.

--- a/src/perl/lib/DnsResolvd.pm
+++ b/src/perl/lib/DnsResolvd.pm
@@ -16,7 +16,13 @@ package DnsResolvd;
 
 use Mojo::Base "Mojolicious";
 
-## Constant: The root route to make GET requests.
+# HTTP request methods.
+use constant {
+    HTTP_GET  => "GET",
+    HTTP_POST => "POST",
+};
+
+## Constant: The root route to make HTTP requests.
 use constant ROOT_ROUTE => "/";
 
 ## Constant: The controller route to make DNS lookup actions.
@@ -33,8 +39,10 @@ sub startup {
     my $router = $self->routes();
 
     # Routing to the DNS lookup controller and action route.
-    $router->get(ROOT_ROUTE)->to(DNS_LOOKUP_CONTROLLER_ROUTE
-                               . DNS_LOOKUP_ACTION_ROUTE);
+    $router->any([
+        HTTP_GET,
+        HTTP_POST,
+    ] =>ROOT_ROUTE)->to(DNS_LOOKUP_CONTROLLER_ROUTE . DNS_LOOKUP_ACTION_ROUTE);
 }
 
 1;

--- a/src/perl/lib/DnsResolvd/ControllerHelper.pm
+++ b/src/perl/lib/DnsResolvd/ControllerHelper.pm
@@ -76,6 +76,9 @@ use constant _HDR_EXPIRES           => "Thu, 01 Dec 1994 16:00:00 GMT";
 use constant _HDR_PRAGMA            => "no-cache";
 use constant _RSC_HTTP_200_OK       => 200;
 
+# Response data names.
+use constant _DAT_VERSION_V  => "IPv";
+
 # Daemon name, version, and copyright banners.
 use constant _DMN_NAME        => "DNS Resolver Daemon (dnsresolvd)";
 use constant _DMN_DESCRIPTION => "Performs DNS lookups for the given hostname "
@@ -129,6 +132,8 @@ our @EXPORT_OK = (
     "_HDR_PRAGMA",
     "_RSC_HTTP_200_OK",
 # -----------------------------------------------------------------------------
+    "_DAT_VERSION_V",
+# -----------------------------------------------------------------------------
     "_DMN_NAME",
     "_DMN_DESCRIPTION",
     "_DMN_VERSION_S__",
@@ -143,17 +148,26 @@ our @EXPORT_OK = (
 # Adds headers to the response.
 #
 # @param ctrl The controller instance object.
+# @param fmt  The response format selector.
 #
 sub add_response_headers {
-    my  $self  = shift();
-    my ($ctrl) = @_;
+    my  $self        = shift();
+    my ($ctrl, $fmt) = @_;
 
     my $headers = $ctrl->res()->headers();
 
-    $headers->content_type (      _HDR_CONTENT_TYPE_HTML);
-    $headers->cache_control(          _HDR_CACHE_CONTROL);
-    $headers->expires      (          _HDR_EXPIRES      );
-    $headers->header       (Pragma => _HDR_PRAGMA       );
+    my $HDR_CONTENT_TYPE_V;
+
+         if ($fmt eq _PRM_FMT_HTML) {
+        $HDR_CONTENT_TYPE_V = _HDR_CONTENT_TYPE_HTML;
+    } elsif ($fmt eq _PRM_FMT_JSON) {
+        $HDR_CONTENT_TYPE_V = _HDR_CONTENT_TYPE_JSON;
+    }
+
+    $headers->content_type (          $HDR_CONTENT_TYPE_V);
+    $headers->cache_control(          _HDR_CACHE_CONTROL );
+    $headers->expires      (          _HDR_EXPIRES       );
+    $headers->header       (Pragma => _HDR_PRAGMA        );
 }
 
 # Helper method. Draws a horizontal separator banner.

--- a/src/perl/lib/DnsResolvd/ControllerHelper.pm
+++ b/src/perl/lib/DnsResolvd/ControllerHelper.pm
@@ -22,37 +22,42 @@ use v5.10;
 use Exporter "import";
 
 # Helper constants.
-use constant _EXIT_FAILURE     =>    1; #    Failing exit status.
-use constant _EXIT_SUCCESS     =>    0; # Successful exit status.
-use constant _EMPTY_STRING     =>   "";
-use constant _ONE_SPACE_STRING =>  " ";
-use constant _COLON_SPACE_SEP  => ": ";
-use constant _COMMA_SPACE_SEP  => ", ";
-use constant _NEW_LINE         => "\n";
-use constant _PRINT_BANNER_OPT => "-V";
+use constant {
+    _EXIT_FAILURE     =>    1, #    Failing exit status.
+    _EXIT_SUCCESS     =>    0, # Successful exit status.
+    _EMPTY_STRING     =>   "",
+    _ONE_SPACE_STRING =>  " ",
+    _COLON_SPACE_SEP  => ": ",
+    _COMMA_SPACE_SEP  => ", ",
+    _NEW_LINE         => "\n",
+    _PRINT_BANNER_OPT => "-V",
+};
 
 # Common error messages and codes.
-use constant _ERR_PREFIX                    => "error";
-use constant _ERR_PORT_MUST_BE_POSITIVE_INT => ": <port_number> must be "
-                                             . "a positive integer value, "
-                                             . "in the range 1024-49151.";
-use constant _ERR_CANNOT_START_SERVER       => ": FATAL: Cannot start server ";
-use constant _ERR_SRV_UNKNOWN_REASON        => "for an unknown reason. "
-                                             . "Exiting...";
-use constant _ERR_SRV_PORT_IS_IN_USE        => "due to the port requested "
-                                             . "is in use. Exiting...";
-use constant _ERR_COULD_NOT_LOOKUP          => "could not lookup hostname";
-use constant _ERR_ADDR_ALREADY_IN_USE       =>
-                                          qr/^.*Address\ already\ in\ use.*$/;
+use constant {
+    _ERR_PREFIX                    => "error",
+    _ERR_PORT_MUST_BE_POSITIVE_INT => ": <port_number> must be "
+                                    . "a positive integer value, "
+                                    . "in the range 1024-49151.",
+    _ERR_CANNOT_START_SERVER       => ": FATAL: Cannot start server ",
+    _ERR_SRV_UNKNOWN_REASON        => "for an unknown reason. Exiting...",
+    _ERR_SRV_PORT_IS_IN_USE        => "due to the port requested is in use. "
+                                    . "Exiting...",
+    _ERR_COULD_NOT_LOOKUP          => "could not lookup hostname",
+    _ERR_ADDR_ALREADY_IN_USE       => qr/^.*Address\ already\ in\ use.*$/,
+};
 
 # Print this error message when there are no any args passed.
-use constant _ERR_MUST_BE_ONE_TWO_ARGS_1 => ": There must be one or two args "
-                                          . "passed: ";
-use constant _ERR_MUST_BE_ONE_TWO_ARGS_2 => " args found";
+use constant {
+    _ERR_MUST_BE_ONE_TWO_ARGS_1 => ": There must be one or two args passed: ",
+    _ERR_MUST_BE_ONE_TWO_ARGS_2 => " args found",
+};
 
 # Print this usage info just after any inappropriate input.
-use constant _MSG_USAGE_TEMPLATE_1 => "Usage: ";
-use constant _MSG_USAGE_TEMPLATE_2 => " <port_number> [-V]";
+use constant {
+    _MSG_USAGE_TEMPLATE_1 => "Usage: ",
+    _MSG_USAGE_TEMPLATE_2 => " <port_number> [-V]",
+};
 
 ## Constant: The minimum port number allowed.
 use constant _MIN_PORT => 1024;
@@ -61,32 +66,40 @@ use constant _MIN_PORT => 1024;
 use constant _MAX_PORT => 49151;
 
 # Common notification messages.
-use constant _MSG_SERVER_STARTED_1 => "Server started on port ";
-use constant _MSG_SERVER_STARTED_2 => "=== Hit Ctrl+C to terminate it.";
+use constant {
+    _MSG_SERVER_STARTED_1 => "Server started on port ",
+    _MSG_SERVER_STARTED_2 => "=== Hit Ctrl+C to terminate it.",
+};
 
 # HTTP request params.
-use constant _PRM_FMT_HTML => "html";
-use constant _PRM_FMT_JSON => "json";
+use constant {
+    _PRM_FMT_HTML => "html",
+    _PRM_FMT_JSON => "json",
+};
 
 # HTTP response headers and status codes.
-use constant _HDR_CONTENT_TYPE_HTML => "text/html; charset=UTF-8";
-use constant _HDR_CONTENT_TYPE_JSON => "application/json";
-use constant _HDR_CACHE_CONTROL     => "no-cache, no-store, must-revalidate";
-use constant _HDR_EXPIRES           => "Thu, 01 Dec 1994 16:00:00 GMT";
-use constant _HDR_PRAGMA            => "no-cache";
-use constant _RSC_HTTP_200_OK       => 200;
+use constant {
+    _HDR_CONTENT_TYPE_HTML => "text/html; charset=UTF-8",
+    _HDR_CONTENT_TYPE_JSON => "application/json",
+    _HDR_CACHE_CONTROL     => "no-cache, no-store, must-revalidate",
+    _HDR_EXPIRES           => "Thu, 01 Dec 1994 16:00:00 GMT",
+    _HDR_PRAGMA            => "no-cache",
+    _RSC_HTTP_200_OK       => 200,
+};
 
 # Response data names.
 use constant _DAT_VERSION_V  => "IPv";
 
 # Daemon name, version, and copyright banners.
-use constant _DMN_NAME        => "DNS Resolver Daemon (dnsresolvd)";
-use constant _DMN_DESCRIPTION => "Performs DNS lookups for the given hostname "
-                               . "passed in an HTTP request";
-use constant _DMN_VERSION_S__ => "Version";
-use constant _DMN_VERSION     => "0.1";
-use constant _DMN_COPYRIGHT__ => "Copyright (C) 2017-2018";
-use constant _DMN_AUTHOR      => "Radislav Golubtsov <ragolubtsov\@my.com>";
+use constant {
+    _DMN_NAME        => "DNS Resolver Daemon (dnsresolvd)",
+    _DMN_DESCRIPTION => "Performs DNS lookups for the given hostname "
+                      . "passed in an HTTP request",
+    _DMN_VERSION_S__ => "Version",
+    _DMN_VERSION     => "0.1",
+    _DMN_COPYRIGHT__ => "Copyright (C) 2017-2018",
+    _DMN_AUTHOR      => "Radislav Golubtsov <ragolubtsov\@my.com>",
+};
 
 ## Constant: The default hostname to look up for.
 use constant _DEF_HOSTNAME => "openbsd.org";

--- a/src/perl/lib/DnsResolvd/ControllerHelper.pm
+++ b/src/perl/lib/DnsResolvd/ControllerHelper.pm
@@ -29,6 +29,7 @@ use constant _ONE_SPACE_STRING =>  " ";
 use constant _COLON_SPACE_SEP  => ": ";
 use constant _COMMA_SPACE_SEP  => ", ";
 use constant _NEW_LINE         => "\n";
+use constant _PRINT_BANNER_OPT => "-V";
 
 # Common error messages and codes.
 use constant _ERR_PREFIX                    => "error";
@@ -45,13 +46,13 @@ use constant _ERR_ADDR_ALREADY_IN_USE       =>
                                           qr/^.*Address\ already\ in\ use.*$/;
 
 # Print this error message when there are no any args passed.
-use constant _ERR_MUST_BE_THE_ONLY_ARG_1 => ": There must be exactly one arg "
+use constant _ERR_MUST_BE_ONE_TWO_ARGS_1 => ": There must be one or two args "
                                           . "passed: ";
-use constant _ERR_MUST_BE_THE_ONLY_ARG_2 => " args found";
+use constant _ERR_MUST_BE_ONE_TWO_ARGS_2 => " args found";
 
 # Print this usage info just after any inappropriate input.
 use constant _MSG_USAGE_TEMPLATE_1 => "Usage: ";
-use constant _MSG_USAGE_TEMPLATE_2 => " <port_number>";
+use constant _MSG_USAGE_TEMPLATE_2 => " <port_number> [-V]";
 
 ## Constant: The minimum port number allowed.
 use constant _MIN_PORT => 1024;
@@ -63,12 +64,17 @@ use constant _MAX_PORT => 49151;
 use constant _MSG_SERVER_STARTED_1 => "Server started on port ";
 use constant _MSG_SERVER_STARTED_2 => "=== Hit Ctrl+C to terminate it.";
 
+# HTTP request params.
+use constant _PRM_FMT_HTML => "html";
+use constant _PRM_FMT_JSON => "json";
+
 # HTTP response headers and status codes.
-use constant _HDR_CONTENT_TYPE  => "text/html; charset=UTF-8";
-use constant _HDR_CACHE_CONTROL => "no-cache, no-store, must-revalidate";
-use constant _HDR_EXPIRES       => "Thu, 01 Dec 1994 16:00:00 GMT";
-use constant _HDR_PRAGMA        => "no-cache";
-use constant _RSC_HTTP_200_OK   => 200;
+use constant _HDR_CONTENT_TYPE_HTML => "text/html; charset=UTF-8";
+use constant _HDR_CONTENT_TYPE_JSON => "application/json";
+use constant _HDR_CACHE_CONTROL     => "no-cache, no-store, must-revalidate";
+use constant _HDR_EXPIRES           => "Thu, 01 Dec 1994 16:00:00 GMT";
+use constant _HDR_PRAGMA            => "no-cache";
+use constant _RSC_HTTP_200_OK       => 200;
 
 # Daemon name, version, and copyright banners.
 use constant _DMN_NAME        => "DNS Resolver Daemon (dnsresolvd)";
@@ -86,10 +92,12 @@ use constant _DEF_HOSTNAME => "openbsd.org";
 our @EXPORT_OK = (
     "_EXIT_FAILURE",
     "_EXIT_SUCCESS",
+    "_EMPTY_STRING",
     "_ONE_SPACE_STRING",
     "_COLON_SPACE_SEP",
     "_COMMA_SPACE_SEP",
     "_NEW_LINE",
+    "_PRINT_BANNER_OPT",
 # -----------------------------------------------------------------------------
     "_ERR_PREFIX",
     "_ERR_PORT_MUST_BE_POSITIVE_INT",
@@ -99,8 +107,8 @@ our @EXPORT_OK = (
     "_ERR_COULD_NOT_LOOKUP",
     "_ERR_ADDR_ALREADY_IN_USE",
 # -----------------------------------------------------------------------------
-    "_ERR_MUST_BE_THE_ONLY_ARG_1",
-    "_ERR_MUST_BE_THE_ONLY_ARG_2",
+    "_ERR_MUST_BE_ONE_TWO_ARGS_1",
+    "_ERR_MUST_BE_ONE_TWO_ARGS_2",
 # -----------------------------------------------------------------------------
     "_MSG_USAGE_TEMPLATE_1",
     "_MSG_USAGE_TEMPLATE_2",
@@ -111,7 +119,11 @@ our @EXPORT_OK = (
     "_MSG_SERVER_STARTED_1",
     "_MSG_SERVER_STARTED_2",
 # -----------------------------------------------------------------------------
-    "_HDR_CONTENT_TYPE",
+    "_PRM_FMT_HTML",
+    "_PRM_FMT_JSON",
+# -----------------------------------------------------------------------------
+    "_HDR_CONTENT_TYPE_HTML",
+    "_HDR_CONTENT_TYPE_JSON",
     "_HDR_CACHE_CONTROL",
     "_HDR_EXPIRES",
     "_HDR_PRAGMA",
@@ -138,7 +150,7 @@ sub add_response_headers {
 
     my $headers = $ctrl->res()->headers();
 
-    $headers->content_type (          _HDR_CONTENT_TYPE );
+    $headers->content_type (      _HDR_CONTENT_TYPE_HTML);
     $headers->cache_control(          _HDR_CACHE_CONTROL);
     $headers->expires      (          _HDR_EXPIRES      );
     $headers->header       (Pragma => _HDR_PRAGMA       );

--- a/src/perl/lib/DnsResolvd/DnsLookupController.pm
+++ b/src/perl/lib/DnsResolvd/DnsLookupController.pm
@@ -21,8 +21,6 @@ use Net::DNS::Native;
 use IO::Select;
 use Socket;
 
-#use Data::Dumper;
-
 use DnsResolvd::ControllerHelper
     "_EXIT_SUCCESS",
     "_ONE_SPACE_STRING",
@@ -36,12 +34,10 @@ use DnsResolvd::ControllerHelper
     "_PRM_FMT_JSON",
 # -----------------------------------------------------------------------------
     "_HDR_CONTENT_TYPE_HTML",
-#    "_HDR_CONTENT_TYPE_JSON",
 # -----------------------------------------------------------------------------
     "_DAT_VERSION_V",
 # -----------------------------------------------------------------------------
     "_DMN_NAME",
-    "_DMN_DESCRIPTION",
 # -----------------------------------------------------------------------------
     "_DEF_HOSTNAME";
 
@@ -127,8 +123,6 @@ sub dns_lookup {
 
     # Waiting until resolving done.
     $sel->can_read();
-
-#   print(Dumper($sel));
 
     my $addr;
     my $ver;

--- a/src/perl/lib/DnsResolvd/DnsLookupController.pm
+++ b/src/perl/lib/DnsResolvd/DnsLookupController.pm
@@ -35,10 +35,8 @@ use DnsResolvd::ControllerHelper
     "_ERR_PREFIX",
     "_ERR_COULD_NOT_LOOKUP",
 # -----------------------------------------------------------------------------
-    "_HDR_CONTENT_TYPE",
-    "_HDR_CACHE_CONTROL",
-    "_HDR_EXPIRES",
-    "_HDR_PRAGMA",
+    "_HDR_CONTENT_TYPE_HTML",
+    "_HDR_CONTENT_TYPE_JSON",
 # -----------------------------------------------------------------------------
     "_DMN_NAME",
     "_DMN_DESCRIPTION",
@@ -49,7 +47,7 @@ use DnsResolvd::ControllerHelper
 use constant RESP_TEMPLATE_1 => "<!DOCTYPE html>"                                           . _NEW_LINE
 . "<html lang=\"en-US\" dir=\"ltr\">"                                                       . _NEW_LINE
 . "<head>"                                                                                  . _NEW_LINE
-. "<meta http-equiv=\"Content-Type\"    content=\"" . _HDR_CONTENT_TYPE . "\"           />" . _NEW_LINE
+. "<meta http-equiv=\"Content-Type\"    content=\"" . _HDR_CONTENT_TYPE_HTML . "\"           />" . _NEW_LINE
 . "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"                            />"  . _NEW_LINE
 . "<meta       name=\"viewport\"        content=\"width=device-width,initial-scale=1\" />"  . _NEW_LINE
 . "<title>" . _DMN_NAME . "</title>"                                                        . _NEW_LINE

--- a/src/perl/lib/DnsResolvd/DnsLookupController.pm
+++ b/src/perl/lib/DnsResolvd/DnsLookupController.pm
@@ -14,13 +14,9 @@
 
 package DnsResolvd::DnsLookupController;
 
-use strict;
-use warnings;
-use utf8;
-use v5.10;
-
 use Mojo::Base "Mojolicious::Controller";
 use Mojo::JSON "encode_json";
+
 use Net::DNS::Native;
 use IO::Select;
 use Socket;

--- a/src/perl/lib/DnsResolvd/DnsLookupController.pm
+++ b/src/perl/lib/DnsResolvd/DnsLookupController.pm
@@ -35,8 +35,11 @@ use DnsResolvd::ControllerHelper
     "_ERR_PREFIX",
     "_ERR_COULD_NOT_LOOKUP",
 # -----------------------------------------------------------------------------
+    "_PRM_FMT_HTML",
+    "_PRM_FMT_JSON",
+# -----------------------------------------------------------------------------
     "_HDR_CONTENT_TYPE_HTML",
-    "_HDR_CONTENT_TYPE_JSON",
+#    "_HDR_CONTENT_TYPE_JSON",
 # -----------------------------------------------------------------------------
     "_DMN_NAME",
     "_DMN_DESCRIPTION",
@@ -86,8 +89,28 @@ sub dns_lookup {
     #                             V
     my $hostname = $query->param("h");
 
+    # http://localhost:<port_number>/?h=<hostname>&f=<fmt>
+    #                                              |
+    #                        +---------------------+
+    #                        |
+    #                        V
+    my $fmt = $query->param("f");
+
     if (!$hostname) {
         $hostname = _DEF_HOSTNAME;
+    }
+
+    if (!$fmt) {
+        $fmt = _PRM_FMT_JSON;
+    } else {
+        $fmt = lc($fmt);
+
+        if (!grep(/^$fmt$/, (
+            _PRM_FMT_HTML,
+            _PRM_FMT_JSON,
+        ))) {
+            $fmt = _PRM_FMT_JSON;
+        }
     }
 
     # Performing DNS lookup for the given hostname

--- a/src/perl/lib/DnsResolvd/DnsLookupController.pm
+++ b/src/perl/lib/DnsResolvd/DnsLookupController.pm
@@ -20,6 +20,7 @@ use utf8;
 use v5.10;
 
 use Mojo::Base "Mojolicious::Controller";
+use Mojo::JSON "encode_json";
 use Net::DNS::Native;
 use IO::Select;
 use Socket;
@@ -41,31 +42,37 @@ use DnsResolvd::ControllerHelper
     "_HDR_CONTENT_TYPE_HTML",
 #    "_HDR_CONTENT_TYPE_JSON",
 # -----------------------------------------------------------------------------
+    "_DAT_VERSION_V",
+# -----------------------------------------------------------------------------
     "_DMN_NAME",
     "_DMN_DESCRIPTION",
 # -----------------------------------------------------------------------------
     "_DEF_HOSTNAME";
 
 # HTTP response buffer template chunks.
-use constant RESP_TEMPLATE_1 => "<!DOCTYPE html>"                                           . _NEW_LINE
-. "<html lang=\"en-US\" dir=\"ltr\">"                                                       . _NEW_LINE
-. "<head>"                                                                                  . _NEW_LINE
+use constant {
+    RESP_TEMPLATE_HTML_1 => "<!DOCTYPE html>"                                                    . _NEW_LINE
+. "<html lang=\"en-US\" dir=\"ltr\">"                                                            . _NEW_LINE
+. "<head>"                                                                                       . _NEW_LINE
 . "<meta http-equiv=\"Content-Type\"    content=\"" . _HDR_CONTENT_TYPE_HTML . "\"           />" . _NEW_LINE
-. "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"                            />"  . _NEW_LINE
-. "<meta       name=\"viewport\"        content=\"width=device-width,initial-scale=1\" />"  . _NEW_LINE
-. "<title>" . _DMN_NAME . "</title>"                                                        . _NEW_LINE
-. "</head>"                                                                                 . _NEW_LINE
-. "<body>"                                                                                  . _NEW_LINE
-. "<div>";
+. "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"                            />"       . _NEW_LINE
+. "<meta       name=\"viewport\"        content=\"width=device-width,initial-scale=1\" />"       . _NEW_LINE
+. "<title>" . _DMN_NAME . "</title>"                                                             . _NEW_LINE
+. "</head>"                                                                                      . _NEW_LINE
+. "<body>"                                                                                       . _NEW_LINE
+. "<div>",
 
-use constant RESP_TEMPLATE_2 => " IPv";
+    RESP_TEMPLATE_HTML_2 => _ONE_SPACE_STRING
+                          . _DAT_VERSION_V,
 
-use constant RESP_TEMPLATE_3 => _ERR_PREFIX . _COLON_SPACE_SEP
-                              . _ERR_COULD_NOT_LOOKUP;
+    RESP_TEMPLATE_HTML_3 => _ERR_PREFIX
+                          . _COLON_SPACE_SEP
+                          . _ERR_COULD_NOT_LOOKUP,
 
-use constant RESP_TEMPLATE_4 => "</div>"  . _NEW_LINE
-                              . "</body>" . _NEW_LINE
-                              . "</html>" . _NEW_LINE;
+    RESP_TEMPLATE_HTML_4 => "</div>"  . _NEW_LINE
+                          . "</body>" . _NEW_LINE
+                          . "</html>" . _NEW_LINE,
+};
 
 ##
 # Performs DNS lookup action for the given hostname,
@@ -155,21 +162,38 @@ sub dns_lookup {
         }       #                                   |
     }           # From the Socket lib. -------------+
 
-    my $resp_buffer = RESP_TEMPLATE_1 . $hostname . _ONE_SPACE_STRING;
+    my $resp_buffer;
 
-    if ($addr eq _ERR_PREFIX) {
-        $resp_buffer .= RESP_TEMPLATE_3;
-    } else {
-        $resp_buffer .= $addr . RESP_TEMPLATE_2 . $ver;
+         if ($fmt eq _PRM_FMT_HTML) {
+        $resp_buffer = RESP_TEMPLATE_HTML_1 . $hostname . _ONE_SPACE_STRING;
+
+        if ($addr eq _ERR_PREFIX) {
+            $resp_buffer .= RESP_TEMPLATE_HTML_3;
+        } else {
+            $resp_buffer .= $addr . RESP_TEMPLATE_HTML_2 . $ver;
+        }
+
+        $resp_buffer .= RESP_TEMPLATE_HTML_4;
+    } elsif ($fmt eq _PRM_FMT_JSON) {
+        if ($addr eq _ERR_PREFIX) {
+            $resp_buffer = encode_json({
+                hostname => $hostname,
+                error    => _ERR_COULD_NOT_LOOKUP,
+            });
+        } else {
+            $resp_buffer = encode_json({
+                hostname => $hostname,
+                address  => $addr,
+                version  => _DAT_VERSION_V . $ver,
+            });
+        }
     }
-
-    $resp_buffer .= RESP_TEMPLATE_4;
 
     # Instantiating the controller helper class.
     my $aux = DnsResolvd::ControllerHelper->new();
 
     # Adding headers to the response.
-    $aux->add_response_headers($self);
+    $aux->add_response_headers($self, $fmt);
 
     # Rendering the response buffer.
     $ret = $self->render(inline => $resp_buffer);


### PR DESCRIPTION
- Implementing producing **JSON** output by default.
- Allowing making **POST** requests.
- Removing the explicit _"strict", "warnings", etc. pragmas_ because **Mojo::Base** automatically enables them.
- Suppressing printing the version and copyright banner by default.