### PR TITLE
libmicrohttpd: Bugfix: Segfaults when there are no request params given at all.

### DIFF
--- a/src/c/dnsresolvd.h
+++ b/src/c/dnsresolvd.h
@@ -66,6 +66,8 @@
 #define _MSG_SERVER_STARTED_2 "=== Hit Ctrl+C to terminate it."
 
 /* HTTP request params. */
+#define _PRM_HOSTNAME "h"
+#define _PRM_FORMAT   "f"
 #define _PRM_FMT_HTML "html"
 #define _PRM_FMT_JSON "json"
 


### PR DESCRIPTION
- Sanitizing **Segfaults** when making requests (both POST and GET) to the daemon with no request params given. :point_right: Fixes [this](https://github.com/rgolubtsov/dnsresolvd-multilang/issues/27) issue.
- Parsing **upload_data** (POST body data) by ourselves instead of using internal iterator facility. :dvd: