### PR TITLE
libsoup/Vala: Produce HTTP response output in HTML (and partially in JSON) format.

### DIFF
--- a/src/vala/Makefile
+++ b/src/vala/Makefile
@@ -30,7 +30,9 @@ VCFLAGS = --target-glib=2.40 --cc=$(CC) -X -s                       \
                                         -X -mtune=generic           \
                                         -X -pipe                    \
                                         -X -fstack-protector-strong \
-          --pkg=posix --pkg=libsoup-2.4 -o
+          --pkg=posix                                               \
+          --pkg=libsoup-2.4                                         \
+          --pkg=json-glib-1.0           -o
 
 # Making the target.
 $(EXEC): $(SRCS)

--- a/src/vala/Makefile
+++ b/src/vala/Makefile
@@ -16,6 +16,10 @@ PREF = dnsresolv
 EXEC = $(PREF)d
 SRCS = $(PREF)d.vala \
        $(PREF)h.gs
+#                ^ ^
+#                | |
+#                | +----- Main   module, in Vala.
+#                +------- Helper module, in Genie.
 
 # Specify flags and other vars here.
 # If we're on OpenBSD, invoke its gcc from packages

--- a/src/vala/dnsresolvd.vala
+++ b/src/vala/dnsresolvd.vala
@@ -220,11 +220,13 @@ public static int main(string[] args) {
         // --- Parsing and validating request params - End --------------------
         // --------------------------------------------------------------------
 
+        var node = new Json.Node(Json.NodeType.OBJECT);
+
         var e    = false; // <--------------+   +--- Setting these vars
         var addr = AUX.EMPTY_STRING; // <---+---+------- as dummies
         var ver  = AUX.EMPTY_STRING; // <---+   +------ for a while.
 
-        if (fmt == AUX.PRM_FMT_HTML) {
+               if (fmt == AUX.PRM_FMT_HTML) {
             resp_buffer = "<!DOCTYPE html>"                                                 + AUX.NEW_LINE
 + "<html lang=\"en-US\" dir=\"ltr\">"                                                       + AUX.NEW_LINE
 + "<head>"                                                                                  + AUX.NEW_LINE
@@ -236,6 +238,8 @@ public static int main(string[] args) {
 + "</head>"                                                                                 + AUX.NEW_LINE
 + "<body>"                                                                                  + AUX.NEW_LINE
 + "<div>"   + hostname     + AUX.SPACE;
+        } else if (fmt == AUX.PRM_FMT_JSON) {
+            node = node.init_object(new Json.Object());
         }
 
         if (e) {
@@ -243,14 +247,18 @@ public static int main(string[] args) {
                 resp_buffer += AUX.ERR_PREFIX
                             +  AUX.COLON_SPACE_SEP
                             +  AUX.ERR_COULD_NOT_LOOKUP;
-            } else if (fmt  == AUX.PRM_FMT_JSON) {}
+            } else if (fmt  == AUX.PRM_FMT_JSON) {
+                resp_buffer  = Json.to_string(node, false);
+            }
         } else {
                    if (fmt  == AUX.PRM_FMT_HTML) {
                 resp_buffer += addr
                             +  AUX.SPACE
                             +  AUX.DAT_VERSION_V
                             +  ver;
-            } else if (fmt  == AUX.PRM_FMT_JSON) {}
+            } else if (fmt  == AUX.PRM_FMT_JSON) {
+                resp_buffer  = Json.to_string(node, true );
+            }
         }
 
         if (fmt == AUX.PRM_FMT_HTML) {

--- a/src/vala/dnsresolvd.vala
+++ b/src/vala/dnsresolvd.vala
@@ -154,7 +154,7 @@ public static int main(string[] args) {
      * @param  qry The query component of the <code>msg</code> request URI.
      */
     dmn.add_handler(null, (dmn, msg, pth, qry) => {
-        uint8[] resp_buffer;
+        var resp_buffer = AUX.EMPTY_STRING;
 
         var mtd      = msg.method;
         var req_body = msg.request_body;
@@ -220,20 +220,55 @@ public static int main(string[] args) {
         // --- Parsing and validating request params - End --------------------
         // --------------------------------------------------------------------
 
-        msg.set_status(Soup.Status.OK);
+        var e    = false; // <--------------+   +--- Setting these vars
+        var addr = AUX.EMPTY_STRING; // <---+---+------- as dummies
+        var ver  = AUX.EMPTY_STRING; // <---+   +------ for a while.
 
-        // Adding headers to the response.
-        var HDR_CONTENT_TYPE = AUX.EMPTY_STRING;
-
-               if (fmt == AUX.PRM_FMT_HTML) {
-            HDR_CONTENT_TYPE = AUX.HDR_CONTENT_TYPE_HTML;
-        } else if (fmt == AUX.PRM_FMT_JSON) {
-            HDR_CONTENT_TYPE = AUX.HDR_CONTENT_TYPE_JSON;
+        if (fmt == AUX.PRM_FMT_HTML) {
+            resp_buffer = "<!DOCTYPE html>"                                                 + AUX.NEW_LINE
++ "<html lang=\"en-US\" dir=\"ltr\">"                                                       + AUX.NEW_LINE
++ "<head>"                                                                                  + AUX.NEW_LINE
++ "<meta http-equiv=\""    + AUX.HDR_CONTENT_TYPE_N      +               "\"    content=\""
+                           + AUX.HDR_CONTENT_TYPE_V_HTML +               "\"           />"  + AUX.NEW_LINE
++ "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"                            />"  + AUX.NEW_LINE
++ "<meta       name=\"viewport\"        content=\"width=device-width,initial-scale=1\" />"  + AUX.NEW_LINE
++ "<title>" + AUX.DMN_NAME + "</title>"                                                     + AUX.NEW_LINE
++ "</head>"                                                                                 + AUX.NEW_LINE
++ "<body>"                                                                                  + AUX.NEW_LINE
++ "<div>"   + hostname     + AUX.SPACE;
         }
 
-        resp_buffer = { 0 };
+        if (e) {
+                   if (fmt  == AUX.PRM_FMT_HTML) {
+                resp_buffer += AUX.ERR_PREFIX
+                            +  AUX.COLON_SPACE_SEP
+                            +  AUX.ERR_COULD_NOT_LOOKUP;
+            } else if (fmt  == AUX.PRM_FMT_JSON) {}
+        } else {
+                   if (fmt  == AUX.PRM_FMT_HTML) {
+                resp_buffer += addr
+                            +  AUX.SPACE
+                            +  AUX.DAT_VERSION_V
+                            +  ver;
+            } else if (fmt  == AUX.PRM_FMT_JSON) {}
+        }
 
-        msg.set_response(HDR_CONTENT_TYPE, Soup.MemoryUse.STATIC, resp_buffer);
+        if (fmt == AUX.PRM_FMT_HTML) {
+            resp_buffer += "</div>"  + AUX.NEW_LINE
+                        +  "</body>" + AUX.NEW_LINE
+                        +  "</html>" + AUX.NEW_LINE;
+        }
+
+        // Adding headers to the response.
+        var HDR_CONTENT_TYPE_V = aux.add_response_headers(msg.response_headers,
+                                 fmt);
+
+        stdout.printf("---" + resp_buffer.length.to_string()
+                    + "---" + resp_buffer
+                    + "---" + AUX.NEW_LINE);
+
+        msg.set_status(Soup.Status.OK);msg.set_response(HDR_CONTENT_TYPE_V,
+                       Soup.MemoryUse.COPY,    resp_buffer.data);
     });
 
     // Trying to start up the daemon.

--- a/src/vala/dnsresolvd.vala
+++ b/src/vala/dnsresolvd.vala
@@ -139,9 +139,21 @@ public static int main(string[] args) {
 
     /*
      * Attaching HTTP request handlers to process incoming requests
-     * and producing the response.
+     * and producing the response. ---+------+------+------+------+
+     *                                |      |      |      |      |
+     *                                v      v      v      v      v
+     *
+     * Default request handler.
+     *
+     * @param _pth The URI path for serving requests. Values <code>null</code>
+     *             or &quot;/&quot; mean that this will be the default handler
+     *             for all requests.
+     * @param  dmn The daemon instance running.
+     * @param  msg The HTTP message being processed.
+     * @param  pth The path  component of the <code>msg</code> request URI.
+     * @param  qry The query component of the <code>msg</code> request URI.
      */
-    dmn.add_handler(null, (dmn, msg, pth, qry) => { // <== Def. req. handler.
+    dmn.add_handler(null, (dmn, msg, pth, qry) => {
         var mtd      = msg.method;
         var req_body = msg.request_body;
 

--- a/src/vala/dnsresolvd.vala
+++ b/src/vala/dnsresolvd.vala
@@ -154,6 +154,8 @@ public static int main(string[] args) {
      * @param  qry The query component of the <code>msg</code> request URI.
      */
     dmn.add_handler(null, (dmn, msg, pth, qry) => {
+        uint8[] resp_buffer;
+
         var mtd      = msg.method;
         var req_body = msg.request_body;
 
@@ -219,6 +221,19 @@ public static int main(string[] args) {
         // --------------------------------------------------------------------
 
         msg.set_status(Soup.Status.OK);
+
+        // Adding headers to the response.
+        var HDR_CONTENT_TYPE = AUX.EMPTY_STRING;
+
+               if (fmt == AUX.PRM_FMT_HTML) {
+            HDR_CONTENT_TYPE = AUX.HDR_CONTENT_TYPE_HTML;
+        } else if (fmt == AUX.PRM_FMT_JSON) {
+            HDR_CONTENT_TYPE = AUX.HDR_CONTENT_TYPE_JSON;
+        }
+
+        resp_buffer = { 0 };
+
+        msg.set_response(HDR_CONTENT_TYPE, Soup.MemoryUse.STATIC, resp_buffer);
     });
 
     // Trying to start up the daemon.

--- a/src/vala/dnsresolvd.vala
+++ b/src/vala/dnsresolvd.vala
@@ -168,6 +168,15 @@ public static int main(string[] args) {
                if (mtd == AUX.MTD_HTTP_GET ) {
             if (qry      != null) {
                 hostname  = qry.get("h");
+                //                   ^
+                //                   |
+                //                   +-------------+
+                //                                 |
+                // http://localhost:<port_number>/?h=<hostname>&f=<fmt>
+                //                                              |
+                //                   +--------------------------+
+                //                   |
+                //                   v
                 fmt       = qry.get("f");
             }
         } else if (mtd == AUX.MTD_HTTP_POST) {
@@ -180,10 +189,15 @@ public static int main(string[] args) {
 
                 var qry_ary = req_body_data.split(AUX.AMPER);
 
-                for (uint i = 0; i < qry_ary.length; i++) {
-                           if (qry_ary[i].has_prefix("h=")) {
-                        hostname = qry_ary[i].substring(2);
-                    } else if (qry_ary[i].has_prefix("f=")) {
+            // $ curl -d 'h=<hostname>&f=<fmt>' http://localhost:<port_number>
+            //            |            |
+            //            |            +-------------------------------+
+            //            +------------------------------------------+ |
+            //                                                       | |
+                for (uint i = 0; i < qry_ary.length; i++) {   //     | |
+                           if (qry_ary[i].has_prefix("h=")) { // <---+ |
+                        hostname = qry_ary[i].substring(2);   //       |
+                    } else if (qry_ary[i].has_prefix("f=")) { // <-----+
                         fmt      = qry_ary[i].substring(2);
                     }
                 }

--- a/src/vala/dnsresolvh.gs
+++ b/src/vala/dnsresolvh.gs
@@ -16,6 +16,7 @@
 class AUX
     // Helper constants.
     const EMPTY_STRING     : string =   ""
+    const COLON_SPACE_SEP  : string = ": "
     const COMMA_SPACE_SEP  : string = ", "
     const NEW_LINE         : string = "\n"
     const S_FMT            : string = "%s"
@@ -26,6 +27,7 @@ class AUX
     const PRINT_BANNER_OPT : string = "-V"
 
     // Common error messages.
+    const ERR_PREFIX                    : string =  "error"
     const ERR_PORT_MUST_BE_POSITIVE_INT : string = ("%s: <port_number> must "
                                                  +  "be a positive integer "
                                                  +  "value, in the range "
@@ -37,6 +39,7 @@ class AUX
     const ERR_SRV_PORT_IS_IN_USE        : string = ("due to the port "
                                                  +  "requested is in use. "
                                                  +  "Exiting...")
+    const ERR_COULD_NOT_LOOKUP          : string =  "could not lookup hostname"
 //  const ERR_ADDR_ALREADY_IN_USE       : string =  "Address already in use"
 
     const ERR_ADDR_ALREADY_IN_USE       : string =  "^.*(\\ is\\ |\\ in\\ ).*$"
@@ -65,8 +68,22 @@ class AUX
     const PRM_FMT_JSON  : string = "json"
 
     // HTTP response headers.
-    const HDR_CONTENT_TYPE_HTML : string = "text/html; charset=UTF-8"
-    const HDR_CONTENT_TYPE_JSON : string = "application/json"
+    const HDR_CONTENT_TYPE_N      : string =  "Content-Type"
+    const HDR_CONTENT_TYPE_V_HTML : string =  "text/html; charset=UTF-8"
+    const HDR_CONTENT_TYPE_V_JSON : string =  "application/json"
+    const HDR_CACHE_CONTROL_N     : string =  "Cache-Control"
+    const HDR_CACHE_CONTROL_V     : string = ("no-cache, no-store, "
+                                           +  "must-revalidate")
+    const HDR_EXPIRES_N           : string =  "Expires"
+    const HDR_EXPIRES_V           : string =  "Thu, 01 Dec 1994 16:00:00 GMT"
+    const HDR_PRAGMA_N            : string =  "Pragma"
+    const HDR_PRAGMA_V            : string =  "no-cache"
+
+    // Response data names.
+    const DAT_HOSTNAME_N : string = "hostname"
+    const DAT_ADDRESS_N  : string = "address"
+    const DAT_VERSION_N  : string = "version"
+    const DAT_VERSION_V  : string = "IPv"
 
     // Daemon name, version, and copyright banners.
     const DMN_NAME        : string =  "DNS Resolver Daemon (dnsresolvd)"
@@ -79,6 +96,31 @@ class AUX
 
     /** Constant: The default hostname to look up for. */
     const DEF_HOSTNAME : string = "openbsd.org"
+
+    /**
+     * Adds headers to the response.
+     *
+     * @param resp_hdrs The response headers object.
+     * @param fmt       The response format selector.
+     *
+     * @return The <code>"Content-Type"</code> response header value
+     *         used in the caller's <code>msg.set_response()</code> method.
+     */
+    def add_response_headers(resp_hdrs : Soup.MessageHeaders,
+                             fmt       : string) : string
+
+        resp_hdrs.append(HDR_CACHE_CONTROL_N, HDR_CACHE_CONTROL_V)
+        resp_hdrs.append(HDR_EXPIRES_N,       HDR_EXPIRES_V      )
+        resp_hdrs.append(HDR_PRAGMA_N,        HDR_PRAGMA_V       )
+
+        var HDR_CONTENT_TYPE_V = EMPTY_STRING
+
+        if      (fmt == PRM_FMT_HTML)
+            HDR_CONTENT_TYPE_V = HDR_CONTENT_TYPE_V_HTML
+        else if (fmt == PRM_FMT_JSON)
+            HDR_CONTENT_TYPE_V = HDR_CONTENT_TYPE_V_JSON
+
+        return HDR_CONTENT_TYPE_V
 
     // Helper method. Makes final buffer cleanups, closes streams, etc.
     def cleanups_fixate(loop : MainLoop = (MainLoop) null) : void

--- a/src/vala/dnsresolvh.gs
+++ b/src/vala/dnsresolvh.gs
@@ -64,6 +64,10 @@ class AUX
     const PRM_FMT_HTML  : string = "html"
     const PRM_FMT_JSON  : string = "json"
 
+    // HTTP response headers.
+    const HDR_CONTENT_TYPE_HTML : string = "text/html; charset=UTF-8"
+    const HDR_CONTENT_TYPE_JSON : string = "application/json"
+
     // Daemon name, version, and copyright banners.
     const DMN_NAME        : string =  "DNS Resolver Daemon (dnsresolvd)"
     const DMN_DESCRIPTION : string = ("Performs DNS lookups for the given "


### PR DESCRIPTION
- Improving doc-head commentary for callbacks.
- Adding headers to the response and producing HTTP response output in _HTML_ format.
- Building against the **[JSON-GLib](http://valadoc.org/json-glib-1.0/index.html)** library to produce _JSON_ output in a response.
- Starting to implement producing _JSON_ output using the **[JSON-GLib](http://valadoc.org/json-glib-1.0/index.html)** library.