### PR TITLE
Cowboy/Elixir: Check against cmd-line args presence and port correctness, besides other things: :point_down:

### DIFF
--- a/src/elixir/Makefile
+++ b/src/elixir/Makefile
@@ -20,7 +20,7 @@ EC      = elixirc
 ECFLAGS = -o
 
 # Making the target.
-$(BEAM): $(____)
+$(BEAM): $(____)/*.ex
 	$(EC) $(ECFLAGS) $(____) $(____)
 
 .PHONY: all clean

--- a/src/elixir/dnsresolvd
+++ b/src/elixir/dnsresolvd
@@ -14,6 +14,52 @@
 
 # TODO: Replace this call with invoking the main or startup function,
 #       then do all the rest.
-Dnsresolvd.dns_lookup(Dnsresolvd._DEF_HOSTNAME)
+Dnsresolvd.dns_lookup(AUX._DEF_HOSTNAME)
+
+defmodule Main do
+    @moduledoc "The entry point container of the daemon."
+
+    @doc """
+    The daemon entry point.
+
+    **Args:**<br />
+        `argc`: The number of command-line arguments.
+        `argv`: The list   of command-line arguments.
+
+    **Returns:**<br />
+        The exit code indicating the daemon overall execution status.
+    """
+    def main(argc, argv) do
+        ret = AUX._EXIT_SUCCESS
+#       ret = AUX._EXIT_FAILURE
+
+        port_number      = if (argc > 0),   do: Enum.at(argv, 0),
+                                          else: 0
+        print_banner_opt = if (argc > 1),   do: Enum.at(argv, 1),
+                                          else: AUX._EMPTY_STRING
+
+        print_banner_opt = String.upcase(print_banner_opt, :ascii)
+
+        if (print_banner_opt === AUX._PRINT_BANNER_OPT) do
+            AUX._separator_draw(AUX._DMN_DESCRIPTION)
+
+        IO.puts(AUX._DMN_NAME <> AUX._COMMA_SPACE_SEP  <> AUX._DMN_VERSION_S__
+     <> AUX._ONE_SPACE_STRING <> AUX._DMN_VERSION      <> AUX._NEW_LINE
+     <> AUX._DMN_DESCRIPTION                           <> AUX._NEW_LINE
+     <> AUX._DMN_COPYRIGHT__  <> AUX._ONE_SPACE_STRING <> AUX._DMN_AUTHOR)
+
+            AUX._separator_draw(AUX._DMN_DESCRIPTION)
+        end
+
+        IO.puts("=== " <> to_string(port_number))
+
+        System.stop(ret)
+    end
+end
+
+argv = System.argv()
+argc = length(argv)
+
+Main.main(argc, argv)
 
 # vim:set nu et ts=4 sw=4:

--- a/src/elixir/dnsresolvd
+++ b/src/elixir/dnsresolvd
@@ -98,8 +98,15 @@ defmodule Main do
             System.halt(ret)
         end
 
-        # Trying to start up the daemon.
-        Dnsresolvd.startup(port_number)
+        # Trying to start up the daemon. <------------------------------+
+        try do #                                                        |
+            Dnsresolvd.startup(port_number) # <---------------------+   |
+        rescue #                                                    |   |
+            e in RuntimeError -> RuntimeError.message(e) # <-----+  |   |
+        end #                                                    |  |   |
+        #      ^         ^        ^   ^   ^         ^   ^        |  |   |
+        #      |         |        |   |   |         |   |        |  |   |
+        # TODO:Implement properly the try construct for starting up the daemon.
 
         # Making final cleanups.
         AUX._cleanups_fixate()

--- a/src/elixir/dnsresolvd
+++ b/src/elixir/dnsresolvd
@@ -12,10 +12,6 @@
 # (See the LICENSE file at the top of the source tree.)
 #
 
-# TODO: Replace this call with invoking the main or startup function,
-#       then do all the rest.
-Dnsresolvd.dns_lookup(AUX._DEF_HOSTNAME)
-
 defmodule Main do
     @moduledoc "The entry point container of the daemon."
 
@@ -101,6 +97,9 @@ defmodule Main do
 
             System.halt(ret)
         end
+
+        # Trying to start up the daemon.
+        Dnsresolvd.startup(port_number)
 
         # Making final cleanups.
         AUX._cleanups_fixate()

--- a/src/elixir/dnsresolvd
+++ b/src/elixir/dnsresolvd
@@ -30,8 +30,8 @@ defmodule Main do
         The exit code indicating the daemon overall execution status.
     """
     def main(argc, argv) do
-        ret = AUX._EXIT_SUCCESS
-#       ret = AUX._EXIT_FAILURE
+        daemon_name = String.trim_leading(__ENV__.file,
+                                                  File.cwd!() <> AUX._SLASH)
 
         port_number      = if (argc > 0),   do: Enum.at(argv, 0),
                                           else: 0
@@ -51,15 +51,69 @@ defmodule Main do
             AUX._separator_draw(AUX._DMN_DESCRIPTION)
         end
 
-        IO.puts("=== " <> to_string(port_number))
+        # Opening the system logger.
+        # Posix.openlog((string) null,
+        #               (Posix.LOG_CONS | Posix.LOG_PID), Posix.LOG_DAEMON)
 
-        System.stop(ret)
+        # Checking for args presence.
+        if (argc === 0) do
+            ret = AUX._EXIT_FAILURE
+
+            IO.puts(:stderr, daemon_name <> AUX._ERR_MUST_BE_ONE_TWO_ARGS_1
+                      <> to_string(argc) <> AUX._ERR_MUST_BE_ONE_TWO_ARGS_2
+                                         <> AUX._NEW_LINE)
+
+            # Posix.syslog(Posix.LOG_ERR,
+            #                  daemon_name <> AUX._ERR_MUST_BE_ONE_TWO_ARGS_1
+            #           <> to_string(argc) <> AUX._ERR_MUST_BE_ONE_TWO_ARGS_2
+            #                              <> AUX._NEW_LINE)
+
+            IO.puts(:stderr, AUX._MSG_USAGE_TEMPLATE_1 <> daemon_name
+                          <> AUX._MSG_USAGE_TEMPLATE_2 <> AUX._NEW_LINE)
+
+            AUX._cleanups_fixate()
+
+            System.halt(ret)
+        end
+
+        # Validating the port number and discarding any rubbish it may contain.
+        port_number = try do
+            String.to_integer(port_number)
+        rescue
+            ArgumentError -> 0
+        end
+
+        # Checking for port correctness.
+        if ((port_number < AUX._MIN_PORT) or (port_number > AUX._MAX_PORT)) do
+            ret = AUX._EXIT_FAILURE
+
+            IO.puts(:stderr, daemon_name <> AUX._ERR_PORT_MUST_BE_POSITIVE_INT
+                                         <> AUX._NEW_LINE)
+
+            # Posix.syslog(Posix.LOG_ERR,
+            #                  daemon_name <> AUX._ERR_PORT_MUST_BE_POSITIVE_INT
+            #                              <> AUX._NEW_LINE)
+
+            IO.puts(:stderr, AUX._MSG_USAGE_TEMPLATE_1 <> daemon_name
+                          <> AUX._MSG_USAGE_TEMPLATE_2 <> AUX._NEW_LINE)
+
+            AUX._cleanups_fixate()
+
+            System.halt(ret)
+        end
+
+        # Making final cleanups.
+        AUX._cleanups_fixate()
+
+        AUX._EXIT_SUCCESS
     end
 end
 
 argv = System.argv()
 argc = length(argv)
 
-Main.main(argc, argv)
+ret = Main.main(argc, argv)
+
+System.stop(ret)
 
 # vim:set nu et ts=4 sw=4:

--- a/src/elixir/lib/dnsresolvd.ex
+++ b/src/elixir/lib/dnsresolvd.ex
@@ -25,6 +25,9 @@ defmodule Dnsresolvd do
         The server exit code when interrupted.
     """
     def startup(port_number) do
+        # TODO: Implement starting up the daemon.
+        #       This function currently is a dummy thing and hence
+        #       it should be populated with the actual code.
         dns_lookup(to_string(port_number) <> AUX._ONE_SPACE_STRING
                                           <> AUX._DEF_HOSTNAME)
     end

--- a/src/elixir/lib/dnsresolvd.ex
+++ b/src/elixir/lib/dnsresolvd.ex
@@ -16,6 +16,20 @@ defmodule Dnsresolvd do
     @moduledoc "The main module of the daemon."
 
     @doc """
+    Starts up the daemon.
+
+    **Args:**<br />
+        `port_number`: The server port number to listen on.
+
+    **Returns:**<br />
+        The server exit code when interrupted.
+    """
+    def startup(port_number) do
+        dns_lookup(to_string(port_number) <> AUX._ONE_SPACE_STRING
+                                          <> AUX._DEF_HOSTNAME)
+    end
+
+    @doc """
     Performs DNS lookup action for the given hostname,
     i.e. (in this case) IP address retrieval by hostname.
 
@@ -32,6 +46,8 @@ defmodule Dnsresolvd do
         #       This function currently is a dummy thing and hence
         #       it should be populated with the actual code.
         IO.puts("=== " <> hostname)
+
+        AUX._EXIT_SUCCESS
     end
 end
 

--- a/src/elixir/lib/dnsresolvd.ex
+++ b/src/elixir/lib/dnsresolvd.ex
@@ -12,23 +12,57 @@
 # (See the LICENSE file at the top of the source tree.)
 #
 
-defmodule Dnsresolvd do
-    @moduledoc """
-    The main module of the daemon.
-    """
+defmodule AUX do
+    @moduledoc "The helper module for the daemon."
 
+    # Helper constants.
+    def _EXIT_FAILURE    , do:    1
+    def _EXIT_SUCCESS    , do:    0
+    def _EMPTY_STRING    , do:   ""
+    def _COLON_SPACE_SEP , do: ": "
+    def _COMMA_SPACE_SEP , do: ", "
+    def _NEW_LINE        , do: "\n"
+    def _C_FMT           , do: "%c"
+    def _AMPER           , do:  "&"
+    def _ONE_SPACE_STRING, do:  " "
+    def _PRINT_BANNER_OPT, do: "-V"
+
+    # Daemon name, version, and copyright banners.
+    def _DMN_NAME       , do: "DNS Resolver Daemon (dnsresolvd)"
+    def _DMN_DESCRIPTION, do: "Performs DNS lookups for the given "
+                          <>  "hostname passed in an HTTP request"
+    def _DMN_VERSION_S__, do: "Version"
+    def _DMN_VERSION    , do: "0.1"
+    def _DMN_COPYRIGHT__, do: "Copyright (C) 2017-2018"
+    def _DMN_AUTHOR     , do: "Radislav Golubtsov <ragolubtsov@my.com>"
+
+    # Constant: The default hostname to look up for.
     def _DEF_HOSTNAME, do: "openbsd.org"
+
+    # Helper function. Draws a horizontal separator banner.
+    def _separator_draw(banner_text) do
+        i = String.length(banner_text)
+
+        for (_ <- i..1), do: IO.write('=')
+
+        IO.puts(_EMPTY_STRING())
+    end
+end
+
+defmodule Dnsresolvd do
+    @moduledoc "The main module of the daemon."
 
     @doc """
     Performs DNS lookup action for the given hostname,
     i.e. (in this case) IP address retrieval by hostname.
 
     **Args:**<br />
-    `hostname`: The effective hostname to look up for.
+        `hostname`: The effective hostname to look up for.
 
-    **Returns:** The array containing IP address of the analyzing host/service
-                 and corresponding IP version (family) used to look up in DNS:
-                 `4` for IPv4-only hosts, `6` for IPv6-capable hosts.
+    **Returns:**<br />
+        The array containing IP address of the analyzing host/service
+        and corresponding IP version (family) used to look up in DNS:
+        `4` for IPv4-only hosts, `6` for IPv6-capable hosts.
     """
     def dns_lookup(hostname) do
         # TODO: Implement performing DNS lookup action for the given hostname.

--- a/src/elixir/lib/dnsresolvd.ex
+++ b/src/elixir/lib/dnsresolvd.ex
@@ -12,43 +12,6 @@
 # (See the LICENSE file at the top of the source tree.)
 #
 
-defmodule AUX do
-    @moduledoc "The helper module for the daemon."
-
-    # Helper constants.
-    def _EXIT_FAILURE    , do:    1
-    def _EXIT_SUCCESS    , do:    0
-    def _EMPTY_STRING    , do:   ""
-    def _COLON_SPACE_SEP , do: ": "
-    def _COMMA_SPACE_SEP , do: ", "
-    def _NEW_LINE        , do: "\n"
-    def _C_FMT           , do: "%c"
-    def _AMPER           , do:  "&"
-    def _ONE_SPACE_STRING, do:  " "
-    def _PRINT_BANNER_OPT, do: "-V"
-
-    # Daemon name, version, and copyright banners.
-    def _DMN_NAME       , do: "DNS Resolver Daemon (dnsresolvd)"
-    def _DMN_DESCRIPTION, do: "Performs DNS lookups for the given "
-                          <>  "hostname passed in an HTTP request"
-    def _DMN_VERSION_S__, do: "Version"
-    def _DMN_VERSION    , do: "0.1"
-    def _DMN_COPYRIGHT__, do: "Copyright (C) 2017-2018"
-    def _DMN_AUTHOR     , do: "Radislav Golubtsov <ragolubtsov@my.com>"
-
-    # Constant: The default hostname to look up for.
-    def _DEF_HOSTNAME, do: "openbsd.org"
-
-    # Helper function. Draws a horizontal separator banner.
-    def _separator_draw(banner_text) do
-        i = String.length(banner_text)
-
-        for (_ <- i..1), do: IO.write('=')
-
-        IO.puts(_EMPTY_STRING())
-    end
-end
-
 defmodule Dnsresolvd do
     @moduledoc "The main module of the daemon."
 

--- a/src/elixir/lib/dnsresolvh.ex
+++ b/src/elixir/lib/dnsresolvh.ex
@@ -1,0 +1,52 @@
+#
+# src/elixir/lib/dnsresolvh.ex
+# =============================================================================
+# DNS Resolver Daemon (dnsresolvd). Version 0.1
+# =============================================================================
+# A daemon that performs DNS lookups for the given hostname
+# passed in an HTTP request, with the focus on its implementation
+# using various programming languages. (Cowboy-boosted impl.)
+# =============================================================================
+# Copyright (C) 2017-2018 Radislav (Radicchio) Golubtsov
+#
+# (See the LICENSE file at the top of the source tree.)
+#
+
+defmodule AUX do
+    @moduledoc "The helper module for the daemon."
+
+    # Helper constants.
+    def _EXIT_FAILURE    , do:    1
+    def _EXIT_SUCCESS    , do:    0
+    def _EMPTY_STRING    , do:   ""
+    def _COLON_SPACE_SEP , do: ": "
+    def _COMMA_SPACE_SEP , do: ", "
+    def _NEW_LINE        , do: "\n"
+    def _C_FMT           , do: "%c"
+    def _AMPER           , do:  "&"
+    def _ONE_SPACE_STRING, do:  " "
+    def _PRINT_BANNER_OPT, do: "-V"
+
+    # Daemon name, version, and copyright banners.
+    def _DMN_NAME       , do: "DNS Resolver Daemon (dnsresolvd)"
+    def _DMN_DESCRIPTION, do: "Performs DNS lookups for the given "
+                          <>  "hostname passed in an HTTP request"
+    def _DMN_VERSION_S__, do: "Version"
+    def _DMN_VERSION    , do: "0.1"
+    def _DMN_COPYRIGHT__, do: "Copyright (C) 2017-2018"
+    def _DMN_AUTHOR     , do: "Radislav Golubtsov <ragolubtsov@my.com>"
+
+    # Constant: The default hostname to look up for.
+    def _DEF_HOSTNAME, do: "openbsd.org"
+
+    # Helper function. Draws a horizontal separator banner.
+    def _separator_draw(banner_text) do
+        i = String.length(banner_text)
+
+        for (_ <- i..1), do: IO.write('=')
+
+        IO.puts(_EMPTY_STRING())
+    end
+end
+
+# vim:set nu ts=4 sw=4:

--- a/src/elixir/lib/dnsresolvh.ex
+++ b/src/elixir/lib/dnsresolvh.ex
@@ -22,10 +22,30 @@ defmodule AUX do
     def _COLON_SPACE_SEP , do: ": "
     def _COMMA_SPACE_SEP , do: ", "
     def _NEW_LINE        , do: "\n"
-    def _C_FMT           , do: "%c"
+    def _SLASH           , do:  "/"
     def _AMPER           , do:  "&"
     def _ONE_SPACE_STRING, do:  " "
     def _PRINT_BANNER_OPT, do: "-V"
+
+    # Common error messages.
+    def _ERR_PORT_MUST_BE_POSITIVE_INT, do: ": <port_number> must be "
+                                        <>  "a positive integer value, "
+                                        <>  "in the range 1024-49151."
+
+    # Print this error message when there are no any args passed.
+    def _ERR_MUST_BE_ONE_TWO_ARGS_1, do: ": There must be one or two args "
+                                     <>  "passed: "
+    def _ERR_MUST_BE_ONE_TWO_ARGS_2, do: " args found"
+
+    # Print this usage info just after any inappropriate input.
+    def _MSG_USAGE_TEMPLATE_1, do: "Usage: "
+    def _MSG_USAGE_TEMPLATE_2, do: " <port_number> [-V]"
+
+    # Constant: The minimum port number allowed.
+    def _MIN_PORT, do: 1024
+
+    # Constant: The maximum port number allowed.
+    def _MAX_PORT, do: 49151
 
     # Daemon name, version, and copyright banners.
     def _DMN_NAME       , do: "DNS Resolver Daemon (dnsresolvd)"
@@ -38,6 +58,12 @@ defmodule AUX do
 
     # Constant: The default hostname to look up for.
     def _DEF_HOSTNAME, do: "openbsd.org"
+
+    # Helper function. Makes final buffer cleanups, closes streams, etc.
+    def _cleanups_fixate() do
+        # Closing the system logger.
+        # Posix.closelog()
+    end
 
     # Helper function. Draws a horizontal separator banner.
     def _separator_draw(banner_text) do


### PR DESCRIPTION
- Introducing the helper module, reformatting @doc commentary, parsing command-line arguments.
- _Separating The Seas_: Bringing out the **helper module** to a separate file.
- Checking against command-line arguments' presence and port's correctness.
- Wrapping in the Dnsresolvd.startup() invocation in a **try construct**; placing additional TODOs.