### PR TITLE
Cowboy/Elixir: Generalizing the daemon's Application structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,7 +1066,7 @@ $ ELIXIR_ERL_OPTIONS="-pz lib erlang_modules/deps/syslog/ebin \
                               erlang_modules/deps/ranch/ebin" \
   ./dnsresolvd 8765
 Server started on port 8765
-=== Hit Ctrl+C to terminate it.
+=== Hit Ctrl+\ to terminate it.
 ```
 
 Example of making **GET** and **POST** requests:

--- a/README.md
+++ b/README.md
@@ -745,6 +745,11 @@ Install the necessary dependencies (`elixir`, `rebar19`, `syslog`, `cowboy`). No
 
 ```
 $ sudo pkg_add -vvvvv elixir rebar19
+$
+$ elixir -v
+Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:2:2] [async-threads:10] [kernel-poll:false]
+
+Elixir 1.6.4 (compiled with OTP 19)
 ```
 
 The `syslog` and `cowboy` packages are essentially **Erlang** packages and they can be installed using normal **Elixir**'ish way &ndash; via its standard Mix build tool. But since the Mix utility doesn't used at all, let's build and install these packages via **rebar**. For that it needs to create a &quot;mock&quot; project and install all the necessary dependencies. The following compound one-liner script will actually do this job.
@@ -1055,12 +1060,28 @@ $ curl -w "\n=== %{http_code}\n=== %{content_type}\n" -d 'f=yaml&h=yaml.org' htt
 OpenBSD/amd64:
 
 ```
-$ ELIXIR_ERL_OPTIONS="-pz lib erlang_modules/deps/syslog/ebin erlang_modules/deps/cowboy/ebin erlang_modules/deps/ranch/ebin" ./dnsresolvd 8765
+$ ELIXIR_ERL_OPTIONS="-pz lib erlang_modules/deps/syslog/ebin \
+                              erlang_modules/deps/cowboy/ebin \
+                              erlang_modules/deps/cowlib/ebin \
+                              erlang_modules/deps/ranch/ebin" \
+  ./dnsresolvd 8765
 Server started on port 8765
 === Hit Ctrl+C to terminate it.
 ```
 
-**TODO:** Provide a couple of examples on how to make **GET** and **POST** requests against the daemon.
+Example of making **GET** and **POST** requests:
+
+```
+$ curl -w "\n=== %{http_code}\n=== %{content_type}\n" http://localhost:8765
+
+=== 500
+===
+$
+$ curl -w "\n=== %{http_code}\n=== %{content_type}\n" -XPOST http://localhost:8765
+
+=== 500
+===
+```
 
 ---
 

--- a/src/elixir/lib/dnsresolvd.ex
+++ b/src/elixir/lib/dnsresolvd.ex
@@ -18,15 +18,19 @@ defmodule DnsResolvd do
     use Application
 
     @doc """
-    Starts up the daemon.
+    Starts up the daemon.<br />
+    It has to be the application module callback, but used directly
+    from the startup script of the daemon.
 
     **Args:**<br />
         `args`: A list containing the server port number to listen on
                 as the first element.
 
     **Returns:**<br />
-        The server exit code when interrupted.
+        The tuple containing the PID of the top supervisor process
+        and the state of the running application (or an empty list).
     """
+    @impl (true)
     def start(_, args) do
         [port_number | _] = args
 
@@ -51,25 +55,40 @@ defmodule DnsResolvd do
         # Starting up the daemon's provided Supervisor (optional).
         DnsResolvs.start_link()
 
+        # Trapping exit signals, i.e. transforming them into {:EXIT} message.
+        Process.flag(:trap_exit, true)
+
+        # Inspecting the daemon's Application process message queue
+        # for the incoming {:EXIT} message, i.e. doing same things
+        # as the Process.sleep(:infinity) inactive call below
+        # until the message received.
+        receive do
+            {:EXIT, from, reason} ->
+                IO.inspect(from)
+                IO.inspect(reason)
+        end
+
+        # --- Use message queue (as above) instead of sleep() call below ------
         # Using this call instead of passing "--no-halt"
         # to the Elixir interpreter. See the file "dnsresolvd.app"
         # for explanation.
-        Process.sleep(:infinity)
+        # Process.sleep(:infinity)
+        # ---------------------------------------------------------------------
     end
 
-    @doc """
-    Performs DNS lookup action for the given hostname,
-    i.e. (in this case) IP address retrieval by hostname.
-
-    **Args:**<br />
-        `hostname`: The effective hostname to look up for.
-
-    **Returns:**<br />
-        The array containing IP address of the analyzing host/service
-        and corresponding IP version (family) used to look up in DNS:
-        `4` for IPv4-only hosts, `6` for IPv6-capable hosts.
-    """
-    def dns_lookup(hostname) do
+    ###
+    # Performs DNS lookup action for the given hostname,
+    # i.e. (in this case) IP address retrieval by hostname.
+    #
+    # Args:
+    #     hostname: The effective hostname to look up for.
+    #
+    # Returns:
+    #     The array containing IP address of the analyzing host/service
+    #     and corresponding IP version (family) used to look up in DNS:
+    #     "4" for IPv4-only hosts, "6" for IPv6-capable hosts.
+    #
+    defp dns_lookup(hostname) do
         # TODO: Implement performing DNS lookup action for the given hostname.
         #       This function currently is a dummy thing and hence
         #       it should be populated with the actual code.
@@ -84,10 +103,26 @@ defmodule DnsResolvs do
 
     use Supervisor
 
+    @doc """
+    Supervisor startup helper.<br />
+    Used to directly start up the `DnsResolvs` supervisor process.
+
+    **Returns:**<br />
+        The PID of the `DnsResolvs` supervisor process.
+    """
     def start_link() do
         Supervisor.start_link(__MODULE__, [])
     end
 
+    @doc """
+    Supervisor init/1 callback.<br />
+    Gets called when the `DnsResolvs` supervisor is about to be started up.
+
+    **Returns:**<br />
+        The tuple containing supervisor flags
+        and child processes' specifications.
+    """
+    @impl (true)
     def init(_) do
         child_procs = [] # <== No child processes do we need.
 

--- a/src/elixir/lib/dnsresolvh.ex
+++ b/src/elixir/lib/dnsresolvh.ex
@@ -48,7 +48,7 @@ defmodule AUX do
 
     # Common notification messages.
     def _MSG_SERVER_STARTED_1, do: "Server started on port "
-    def _MSG_SERVER_STARTED_2, do: "=== Hit Ctrl+C to terminate it."
+    def _MSG_SERVER_STARTED_2, do: "=== Hit Ctrl+\\ to terminate it."
 
     # Daemon name, version, and copyright banners.
     def _DMN_NAME       , do: "DNS Resolver Daemon (dnsresolvd)"


### PR DESCRIPTION
- Specifying additional dependency for **Cowboy** when starting up the daemon &ndash; **Cowlib**.
- Adding an example of making GET and POST requests against the daemon.
- Replacing the `Process.sleep()` call with a construct for inspecting process message queue.
- Making the `dns_lookup()` function to be private.
- Actualizing ExDoc commentary blocks and adding them where absent.
- Terminating the daemon by hitting <Ctrl+\\> instead of <Ctrl+C>.