### PR TITLE
Cowboy/Erlang: Further porting from Elixir to Erlang.

### DIFF
--- a/src/erlang/lib/dnsresolvd.erl
+++ b/src/erlang/lib/dnsresolvd.erl
@@ -15,7 +15,9 @@
 %% @doc The main --application-- module of the daemon.
 -module(dnsresolvd).
 
--export([start/2]).
+-behaviour(application).
+
+-export([start/2, stop/1]).
 
 -include("dnsresolvd.h").
 
@@ -99,5 +101,10 @@ start(_, Args) ->
     receive
         {'EXIT', _, _} -> []
     end.
+
+% Does nothing. Required to satisfy the --application-- behaviour
+%               callback module design only.
+stop(_) ->
+    ok.
 
 % vim:set nu et ts=4 sw=4:

--- a/src/erlang/lib/dnsresolvd.erl
+++ b/src/erlang/lib/dnsresolvd.erl
@@ -35,7 +35,7 @@ start(_, Args) ->
 
     Dispatch = cowboy_router:compile([
         {'_', [
-            {"/", req_handler, []}
+            {"/", reqhandler, []}
         ]}
     ]),
 

--- a/src/erlang/lib/dnsresolvd.erl
+++ b/src/erlang/lib/dnsresolvd.erl
@@ -97,9 +97,7 @@ start(_, Args) ->
     % Inspecting the daemon's --application-- process message queue
     % for the incoming {'EXIT'} message until the message received.
     receive
-        {'EXIT', From, Reason} ->
-            io:put_chars(From   ++ ?_NEW_LINE),
-            io:put_chars(Reason ++ ?_NEW_LINE)
+        {'EXIT', _, _} -> []
     end.
 
 % vim:set nu et ts=4 sw=4:

--- a/src/erlang/lib/dnsresolvd.h
+++ b/src/erlang/lib/dnsresolvd.h
@@ -57,6 +57,12 @@
 -define(_MSG_SERVER_STARTED_1, "Server started on port ").
 -define(_MSG_SERVER_STARTED_2, "=== Hit Ctrl+C to terminate it.").
 
+% HTTP request methods and params.
+-define(_MTD_HTTP_GET,  <<"GET">>).
+-define(_MTD_HTTP_POST, <<"POST">>).
+-define(_PRM_FMT_HTML,    "html").
+-define(_PRM_FMT_JSON,    "json").
+
 % Daemon name, version, and copyright banners.
 -define(_DMN_NAME,        "DNS Resolver Daemon (dnsresolvd)").
 -define(_DMN_DESCRIPTION, "Performs DNS lookups for the given "

--- a/src/erlang/lib/dnsresolvs.erl
+++ b/src/erlang/lib/dnsresolvs.erl
@@ -15,7 +15,7 @@
 %% @doc The main --supervisor-- module of the daemon.
 -module(dnsresolvs).
 
--behavior(supervisor).
+-behaviour(supervisor).
 
 -export([start_link/0, init/1]).
 

--- a/src/erlang/lib/reqhandler.erl
+++ b/src/erlang/lib/reqhandler.erl
@@ -1,0 +1,56 @@
+%
+% src/erlang/lib/reqhandler.erl
+% =============================================================================
+% DNS Resolver Daemon (dnsresolvd). Version 0.1
+% =============================================================================
+% A daemon that performs DNS lookups for the given hostname
+% passed in an HTTP request, with the focus on its implementation
+% using various programming languages. (Cowboy-boosted impl.)
+% =============================================================================
+% Copyright (C) 2017-2018 Radislav (Radicchio) Golubtsov
+%
+% (See the LICENSE file at the top of the source tree.)
+%
+
+%% @doc The default HTTP request handler.
+-module(reqhandler).
+
+-export([init/2]).
+
+-include("dnsresolvd.h").
+
+%% @doc The request handler `init/2` callback.<br />
+%%      Gets called when a new incoming HTTP request is received.
+%%
+%% @param Req   The incoming HTTP request object.
+%% @param State The initial state of the HTTP handler.
+%%
+%% @returns The tuple containing the HTTP response to be rendered
+%%          and a new state of the HTTP handler.
+init(Req, State) ->
+    Mtd = cowboy_req:method(Req),
+
+    io:put_chars("==> " ++ Mtd), io:nl(),
+
+    % -------------------------------------------------------------------------
+    % --- Parsing and validating request params - Begin -----------------------
+    % -------------------------------------------------------------------------
+    {ok, Params, Req_} = if (Mtd =:= ?_MTD_HTTP_GET ) ->
+        {ok, cowboy_req:parse_qs(Req), Req};
+                            (Mtd =:= ?_MTD_HTTP_POST) ->
+        cowboy_req:read_urlencoded_body(Req);
+                            (true                   ) ->
+        {ok, [], false}
+                         end,
+
+    io:write(Params), io:nl(),
+    % -------------------------------------------------------------------------
+    % --- Parsing and validating request params - End -------------------------
+    % -------------------------------------------------------------------------
+
+    {ok,
+        Req_,
+        State % <== The state of the handler doesn't need to be changed.
+    }.
+
+% vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Using the _canonical_ "**behaviour**" module tag, though both spellings "**-iour**" and "**-ior**" are accepted.
- Not reacting to the EXIT message: instead simply daemonizing and waiting for incoming connections. :smiley:
- Renaming the request handler module.
- Introducing the default HTTP request handler module, rudimentary for the moment.
- Identifying the main **application** module of the daemon as the _application behaviour callback module_.
- Adding new constants: HTTP request methods and params.