### PR TITLE
Cowboy/LFE: Start up the plain HTTP listener on the port provided.

### DIFF
--- a/src/lfe/dnsresolvd
+++ b/src/lfe/dnsresolvd
@@ -27,8 +27,12 @@
 
     ; --- Error: ./dnsresolvd:XX: function #(FILE 0) undefined ----------------
     ; (let ((daemon-name (: filename basename (FILE))))
+    ; --- -no-module- ---------------------------------------------------------
+    ; (let ((daemon-name (: filename basename (MODULE))))
+    ; --- lfescript -----------------------------------------------------------
+    ; (let ((daemon-name (: os getenv "LFE_PROGNAME")))
     ; -------------------------------------------------------------------------
-    (let ((daemon-name (: filename basename (MODULE))))
+    (let ((daemon-name "dnsresolvd"))
 
     (let ((port-number-      (if (> argc 0) (element 1 argv)
                                             0)))

--- a/src/lfe/dnsresolvd
+++ b/src/lfe/dnsresolvd
@@ -92,7 +92,7 @@
     (let ((port-number (try
         (list_to_integer port-number-)
     (catch
-        ((tuple 'error 'badarg -) 0)
+        ((tuple 'error 'badarg _) 0)
     ))))
 
     ; Checking for port correctness.

--- a/src/lfe/lib/dnsresolvd.lfe
+++ b/src/lfe/lib/dnsresolvd.lfe
@@ -21,7 +21,7 @@
 ;           (stop  1))
 )
 
-(defun start (- args)
+(defun start (_ args)
     "Starts up the daemon.
      It has to be the application module callback, but used directly
      from the startup script of the daemon."
@@ -29,7 +29,7 @@
     'ok
 )
 
-(defun stop (-)
+(defun stop (_)
     "Does nothing. Required to satisfy the --application-- behaviour
                    callback module design only."
 

--- a/src/lfe/lib/dnsresolvd.lfe
+++ b/src/lfe/lib/dnsresolvd.lfe
@@ -18,7 +18,6 @@
     (behaviour application)
 
     (export (start 2))
-;           (stop  1))
 )
 
 #|
@@ -58,13 +57,6 @@
     (receive
         (() (tuple 'EXIT '_ '_))
     )
-)
-
-(defun stop (_)
-    "Does nothing. Required to satisfy the --application-- behaviour
-                   callback module design only."
-
-    'ok
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/lfe/lib/dnsresolvh.lfe
+++ b/src/lfe/lib/dnsresolvh.lfe
@@ -147,7 +147,7 @@
 
     (let ((i (length banner-text)))
 
-    (lc  ((<- - (: lists seq 1 i))) (: io put_chars "="))) (: io nl)
+    (lc  ((<- _ (: lists seq 1 i))) (: io put_chars "="))) (: io nl)
 )
 
 ; vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Setting the daemon name explicitly while the `(FILE)` macro haven't be implemented in LFE.
- Utilizing the "**don't care**" (`_`) variable, just like in Erlang.
- Starting up the plain HTTP listener on the port provided.
- Getting rid of unneeded `stop/1` callback function.