### PR TITLE
HTTP Kit/Clojure: Implement the daemon entry point function almost completely.

### DIFF
--- a/src/clojure/dnsresolvd
+++ b/src/clojure/dnsresolvd
@@ -14,45 +14,108 @@
 
 (ns dnsresolvd
     (:require [dnsresolvh :as AUX])
+    (:require  dnsresolvd         )
 )
 
 (defn main
     "The daemon entry point."
-    [args]
+    [argv]
 
     (let [ret- (AUX/EXIT-SUCCESS)]
 
-    (println ret-)
+    (let [argc (count argv)]
 
-    (let [argv        args ]
-    (let [argc (count args)]
+    (let [daemon-name (str *ns*)]
 
-    (println argv)
-    (println argc)
-    )))
+    (let [port-number-      (if (> argc 0) (nth argv 0)
+                                           0)]
+    (let [print-banner-opt- (if (> argc 1) (nth argv 1)
+                                           (AUX/EMPTY-STRING))]
 
-;   TODO: Implement the daemon entry point function.
+    (let [print-banner-opt (clojure.string/upper-case print-banner-opt-)]
+
+    (cond
+        (= print-banner-opt (AUX/PRINT-BANNER-OPT))
+            (println (str
+            (AUX/DMN-NAME        ) (AUX/COMMA-SPACE-SEP ) (AUX/DMN-VERSION-S--)
+            (AUX/ONE-SPACE-STRING) (AUX/DMN-VERSION     ) (AUX/NEW-LINE       )
+            (AUX/DMN-DESCRIPTION )                        (AUX/NEW-LINE       )
+            (AUX/DMN-COPYRIGHT-- ) (AUX/ONE-SPACE-STRING) (AUX/DMN-AUTHOR     )
+            ))
+    )
+
+    ; Opening the system logger.
+    (let [log (AUX/EMPTY-STRING)] ; <== Dummy val... for a while.
+    ; TODO: Implement opening the system logger.
+
+    ; Checking for args presence.
+    (cond
+        (= argc 0)
+            (let [ret0 (AUX/EXIT-FAILURE)]
+
+            (binding [*out* *err*]
+            (println (str daemon-name (AUX/ERR-MUST-BE-ONE-TWO-ARGS-1)
+                                 argc (AUX/ERR-MUST-BE-ONE-TWO-ARGS-2)
+                                      (AUX/NEW-LINE)))
+
+            (println (str (AUX/MSG-USAGE-TEMPLATE-1) daemon-name
+                          (AUX/MSG-USAGE-TEMPLATE-2) (AUX/NEW-LINE)))
+            )
+
+            (System/exit ret0)
+            )
+    )
+
+    ; Validating the port number and discarding any rubbish it may contain.
+    (let [port-number (Long. (re-find #"\d+" port-number-))]
+
+    ; Checking for port correctness.
+    (cond
+        (or (< port-number (AUX/MIN-PORT)) (> port-number (AUX/MAX-PORT)))
+            (let [ret1 (AUX/EXIT-FAILURE)]
+
+            (binding [*out* *err*]
+            (println (str daemon-name (AUX/ERR-PORT-MUST-BE-POSITIVE-INT)
+                                      (AUX/NEW-LINE)))
+
+            (println (str (AUX/MSG-USAGE-TEMPLATE-1) daemon-name
+                          (AUX/MSG-USAGE-TEMPLATE-2) (AUX/NEW-LINE)))
+            )
+
+            (System/exit ret1)
+            )
+    )
+
+    ; Starting up the daemon.
+    (startup (list
+        port-number
+        daemon-name
+        log
+    )))))))))
+
+    (System/exit ret-)
+    )
 )
 
-(println *compile-path*)
+;(println *compile-path*)
 
 ; --- Adding a custom classpath entry (dir) -----------------------------------
 ; Var names stand for:
 ; acl ==> sun.misc.Launcher$AppClassLoader
 ; fld ==> java.lang.reflect.Field
 ; ucp ==> sun.misc.URLClassPath
-
-(defmacro LIB-URL [] "file:./lib/")
-
-(let [acl (ClassLoader/getSystemClassLoader)                   ] (println (seq (.getURLs acl)))
-(let [fld (aget (.getDeclaredFields java.net.URLClassLoader) 0)] (println                fld  )
-          (.setAccessible fld true) ; <== Important: suppressing Java language access checking.
-(let [ucp (.get    fld acl)                                    ] (println                ucp  )
-          (.addURL ucp (java.net.URL. (LIB-URL)))                (println (seq (.getURLs acl)))
-)))
+;
+;(defmacro LIB-URL [] "file:./lib/")
+;
+;(let [acl (ClassLoader/getSystemClassLoader)                   ] (println (seq (.getURLs acl)))
+;(let [fld (aget (.getDeclaredFields java.net.URLClassLoader) 0)] (println                fld  )
+;          (.setAccessible fld true) ; <== Important: suppressing Java language access checking.
+;(let [ucp (.get    fld acl)                                    ] (println                ucp  )
+;          (.addURL ucp (java.net.URL. (LIB-URL)))                (println (seq (.getURLs acl)))
+;)))
 ; -----------------------------------------------------------------------------
 
-(println *compile-path*)
+;(println *compile-path*)
 
 (main *command-line-args*)
 

--- a/src/clojure/src/dnsresolvh.clj
+++ b/src/clojure/src/dnsresolvh.clj
@@ -24,6 +24,35 @@
 (defmacro ONE-SPACE-STRING []  " ")
 (defmacro PRINT-BANNER-OPT [] "-V")
 
+; Common error messages.
+(defmacro ERR-PORT-MUST-BE-POSITIVE-INT [](str ": <port_number> must be "
+                                               "a positive integer value, "
+                                               "in the range 1024-49151."))
+
+; Print this error message when there are no any args passed.
+(defmacro ERR-MUST-BE-ONE-TWO-ARGS-1 [](str ": There must be one or two args "
+                                            "passed: "))
+(defmacro ERR-MUST-BE-ONE-TWO-ARGS-2 [] " args found"  )
+
+; Print this usage info just after any inappropriate input.
+(defmacro MSG-USAGE-TEMPLATE-1 [] "Usage: "            )
+(defmacro MSG-USAGE-TEMPLATE-2 [] " <port_number> [-V]")
+
+;; Constant: The minimum port number allowed.
+(defmacro MIN-PORT []  1024)
+
+;; Constant: The maximum port number allowed.
+(defmacro MAX-PORT [] 49151)
+
+; Daemon name, version, and copyright banners.
+(defmacro DMN-NAME        [] "DNS Resolver Daemon (dnsresolvd)"       )
+(defmacro DMN-DESCRIPTION [](str "Performs DNS lookups for the given "
+                                 "hostname passed in an HTTP request"))
+(defmacro DMN-VERSION-S-- [] "Version"                                )
+(defmacro DMN-VERSION     [] "0.1"                                    )
+(defmacro DMN-COPYRIGHT-- [] "Copyright (C) 2017-2019"                )
+(defmacro DMN-AUTHOR      [] "Radislav Golubtsov <ragolubtsov@my.com>")
+
 ; TODO: Implement further helper stuff.
 
 ; vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Defining additional constants.
- Importing the main daemon module.
- Getting rid of debug info.
- Disabling adding a custom classpath entry.
- Implementing the daemon entry point function almost completely.