### PR TITLE
HTTP Kit/Clojure: Disable AOT compilation; draw horizontal separator banners; implement port number validation mech completely.

### DIFF
--- a/src/clojure/Makefile
+++ b/src/clojure/Makefile
@@ -14,8 +14,8 @@
 
 LIB = lib
 SRC = src
-NSS = dnsresolvh \
-      dnsresolvd
+#NSS = dnsresolvh \
+#      dnsresolvd
 
 # Specify flags and other vars here.
 MKDIR   = mkdir
@@ -27,11 +27,11 @@ RMFLAGS = -vR
 $(LIB): $(SRC)/*
 	if [ ! -d "$(LIB)" ]; then                                             \
 		$(MKDIR) $(LIB);                                               \
-		for ns in $(NSS); do                                           \
-			$(CL) $(CLFLAGS) "(binding [*compile-path* \"$(LIB)\"] \
-                                          (println  *compile-path*)            \
-                                          (compile (symbol \"$$ns\")))";       \
-		done                                                           \
+#		for ns in $(NSS); do                                           \
+#			$(CL) $(CLFLAGS) "(binding [*compile-path* \"$(LIB)\"] \
+#                                         (println  *compile-path*)            \
+#                                         (compile (symbol \"$$ns\")))";       \
+#		done                                                           \
 	fi
 
 .PHONY: all clean

--- a/src/clojure/dnsresolvd
+++ b/src/clojure/dnsresolvd
@@ -35,13 +35,19 @@
     (let [print-banner-opt (clojure.string/upper-case print-banner-opt-)]
 
     (cond
-        (= print-banner-opt (AUX/PRINT-BANNER-OPT))
+        (= print-banner-opt (AUX/PRINT-BANNER-OPT)) (do
+
+            (AUX/separator-draw (AUX/DMN-DESCRIPTION))
+
             (println (str
             (AUX/DMN-NAME        ) (AUX/COMMA-SPACE-SEP ) (AUX/DMN-VERSION-S--)
             (AUX/ONE-SPACE-STRING) (AUX/DMN-VERSION     ) (AUX/NEW-LINE       )
             (AUX/DMN-DESCRIPTION )                        (AUX/NEW-LINE       )
             (AUX/DMN-COPYRIGHT-- ) (AUX/ONE-SPACE-STRING) (AUX/DMN-AUTHOR     )
             ))
+
+            (AUX/separator-draw (AUX/DMN-DESCRIPTION))
+        )
     )
 
     ; Opening the system logger.
@@ -62,12 +68,18 @@
                           (AUX/MSG-USAGE-TEMPLATE-2) (AUX/NEW-LINE)))
             )
 
+            (AUX/cleanups-fixate log)
+
             (System/exit ret0)
             )
     )
 
     ; Validating the port number and discarding any rubbish it may contain.
-    (let [port-number (Long. (re-find #"\d+" port-number-))]
+    (let [port-number (try
+        (Long. (re-find #"\d+" port-number-))
+    (catch
+        Exception e 0
+    ))]
 
     ; Checking for port correctness.
     (cond
@@ -82,6 +94,8 @@
                           (AUX/MSG-USAGE-TEMPLATE-2) (AUX/NEW-LINE)))
             )
 
+            (AUX/cleanups-fixate log)
+
             (System/exit ret1)
             )
     )
@@ -91,7 +105,11 @@
         port-number
         daemon-name
         log
-    )))))))))
+    )))
+
+    ; Making final cleanups.
+    (AUX/cleanups-fixate log)
+    ))))))
 
     (System/exit ret-)
     )

--- a/src/clojure/src/dnsresolvh.clj
+++ b/src/clojure/src/dnsresolvh.clj
@@ -53,6 +53,21 @@
 (defmacro DMN-COPYRIGHT-- [] "Copyright (C) 2017-2019"                )
 (defmacro DMN-AUTHOR      [] "Radislav Golubtsov <ragolubtsov@my.com>")
 
-; TODO: Implement further helper stuff.
+(defn cleanups-fixate
+    "Helper function. Makes final buffer cleanups, closes streams, etc."
+    [log]
+
+    ; Closing the system logger.
+    ; TODO: Implement closing the system logger.
+)
+
+(defn separator-draw
+    "Helper function. Draws a horizontal separator banner."
+    [banner-text]
+
+    (let [i (count banner-text)]
+
+    (print (apply str (for [_ (range 0 i)] "=")))) (newline)
+)
 
 ; vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Disabling AOT compilation for a while; compile on-the-fly for now.
- Adding two helper functions: to make final cleanups and to draw horizontal separator banners in the copyright and version number block.
- Implementing the port number validation mech completely.