### PR TITLE
HTTP Kit/Clojure: Perform a DNS lookup action for the given hostname.

### DIFF
--- a/src/clojure/src/dnsresolvh.clj
+++ b/src/clojure/src/dnsresolvh.clj
@@ -29,6 +29,7 @@
 (defmacro PARAMS-SEPS      [] #"=|&")
 
 ; Common error messages.
+(defmacro ERR-PREFIX                    [] "error"                        )
 (defmacro ERR-PORT-MUST-BE-POSITIVE-INT [](str ": <port_number> must be "
                                                "a positive integer value, "
                                                "in the range 1024-49151."))


### PR DESCRIPTION
Performing a **DNS lookup** action for the given hostname and returning its _IP address_ and _IP version_ or the _error_ literal if not found.