### PR TITLE
HTTP Kit/Clojure: Replace home-brewed JSON output with calls from the JSON Utilities lib.

### DIFF
--- a/src/clojure/Makefile
+++ b/src/clojure/Makefile
@@ -33,13 +33,17 @@ $(LIB): $(SRC)s/*
 		$(MKDIR) $(LIB);                                                                              \
 		$(ECHO) "------------ Start  ahead-of-time compilation for modules in $(SRC)/ -------------"; \
 		for ns in $(NSS); do                                                                          \
-			$(CL) $(CLFLAGS) "(defmacro DEP-URL [] (str                                           \
-                                         \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\"    \
-                                         \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))                     \
+			$(CL) $(CLFLAGS) "(defmacro DEP-PREF [] (str                                          \
+                                          \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\")) \
+                                          (defmacro DEP-URL0 [] (str                                          \
+                                          (DEP-PREF) \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))         \
+                                          (defmacro DEP-URL1 [] (str                                          \
+                                          (DEP-PREF) \"org/clojure/data.json/0.2.6/data.json-0.2.6.jar\"))    \
                 (let [acl (ClassLoader/getSystemClassLoader)                   ]                              \
                 (let [fld (aget (.getDeclaredFields java.net.URLClassLoader) 0)] (.setAccessible fld true)    \
                 (let [ucp (.get    fld acl)                                    ]                              \
-                          (.addURL ucp (java.net.URL. (DEP-URL)))                                             \
+                          (.addURL ucp (java.net.URL. (DEP-URL0)))                                            \
+                          (.addURL ucp (java.net.URL. (DEP-URL1)))                                            \
                 )))                                                                                           \
                                           (binding [*compile-path* \"$(LIB)\"]                                \
                                           (compile (symbol \"$$ns\")))";                                      \

--- a/src/clojure/README.md
+++ b/src/clojure/README.md
@@ -102,13 +102,17 @@ if [ ! -d "lib" ]; then                                                         
         mkdir lib;                                                                              \
         echo "------------ Start  ahead-of-time compilation for modules in src/ -------------"; \
         for ns in dnsresolvh dnsresolvd; do                                                                          \
-                clojure -e "(defmacro DEP-URL [] (str                                           \
-                                         \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\"    \
-                                         \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))                     \
+                clojure -e "(defmacro DEP-PREF [] (str                                          \
+                                          \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\")) \
+                                          (defmacro DEP-URL0 [] (str                                          \
+                                          (DEP-PREF) \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))         \
+                                          (defmacro DEP-URL1 [] (str                                          \
+                                          (DEP-PREF) \"org/clojure/data.json/0.2.6/data.json-0.2.6.jar\"))    \
                 (let [acl (ClassLoader/getSystemClassLoader)                   ]                              \
                 (let [fld (aget (.getDeclaredFields java.net.URLClassLoader) 0)] (.setAccessible fld true)    \
                 (let [ucp (.get    fld acl)                                    ]                              \
-                          (.addURL ucp (java.net.URL. (DEP-URL)))                                             \
+                          (.addURL ucp (java.net.URL. (DEP-URL0)))                                            \
+                          (.addURL ucp (java.net.URL. (DEP-URL1)))                                            \
                 )))                                                                                           \
                                           (binding [*compile-path* \"lib\"]                                \
                                           (compile (symbol \"$ns\")))";                                      \
@@ -118,9 +122,13 @@ fi;                                                                             
 mv -v src srcs
 srcs -> src
 ------------ Start  ahead-of-time compilation for modules in src/ -------------
-#'user/DEP-URL
+#'user/DEP-PREF
+#'user/DEP-URL0
+#'user/DEP-URL1
 dnsresolvh
-#'user/DEP-URL
+#'user/DEP-PREF
+#'user/DEP-URL0
+#'user/DEP-URL1
 dnsresolvd
 ------------ Finish ahead-of-time compilation for modules in src/ -------------
 src -> srcs

--- a/src/clojure/README.md
+++ b/src/clojure/README.md
@@ -575,13 +575,17 @@ if [ ! -d "lib" ]; then                                                         
         mkdir lib;                                                                              \
         echo "------------ Start  ahead-of-time compilation for modules in src/ -------------"; \
         for ns in dnsresolvh dnsresolvd; do                                                                          \
-                clojure -e "(defmacro DEP-URL [] (str                                           \
-                                         \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\"    \
-                                         \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))                     \
+                clojure -e "(defmacro DEP-PREF [] (str                                          \
+                                          \"file:\" (System/getProperty \"user.home\") \"/.m2/repository/\")) \
+                                          (defmacro DEP-URL0 [] (str                                          \
+                                          (DEP-PREF) \"http-kit/http-kit/2.3.0/http-kit-2.3.0.jar\"))         \
+                                          (defmacro DEP-URL1 [] (str                                          \
+                                          (DEP-PREF) \"org/clojure/data.json/0.2.6/data.json-0.2.6.jar\"))    \
                 (let [acl (ClassLoader/getSystemClassLoader)                   ]                              \
                 (let [fld (aget (.getDeclaredFields java.net.URLClassLoader) 0)] (.setAccessible fld true)    \
                 (let [ucp (.get    fld acl)                                    ]                              \
-                          (.addURL ucp (java.net.URL. (DEP-URL)))                                             \
+                          (.addURL ucp (java.net.URL. (DEP-URL0)))                                            \
+                          (.addURL ucp (java.net.URL. (DEP-URL1)))                                            \
                 )))                                                                                           \
                                           (binding [*compile-path* \"lib\"]                                \
                                           (compile (symbol \"$ns\")))";                                      \
@@ -591,9 +595,13 @@ fi;                                                                             
 mv -v src srcs
 renamed 'srcs' -> 'src'
 ------------ Start  ahead-of-time compilation for modules in src/ -------------
-#'user/DEP-URL
+#'user/DEP-PREF
+#'user/DEP-URL0
+#'user/DEP-URL1
 dnsresolvh
-#'user/DEP-URL
+#'user/DEP-PREF
+#'user/DEP-URL0
+#'user/DEP-URL1
 dnsresolvd
 ------------ Finish ahead-of-time compilation for modules in src/ -------------
 renamed 'src' -> 'srcs'

--- a/src/clojure/dnsresolvd
+++ b/src/clojure/dnsresolvd
@@ -17,7 +17,8 @@
 (defmacro DEP-PREF [] (str
     (DEP-PROT) (System/getProperty "user.home") "/.m2/repository/"))
 (defmacro DEP-URL0 [] (str
-    (DEP-PREF) "org/graylog2/syslog4j/0.9.60/syslog4j-0.9.60.jar"))
+    (DEP-PREF) "org/graylog2/syslog4j/0.9.61-SNAPSHOT/syslog4j-0.9.61-SNAPSHOT.jar"))
+;   (DEP-PREF) "org/graylog2/syslog4j/0.9.60/syslog4j-0.9.60.jar"))
 ;   (DEP-PREF) "org/graylog2/syslog4j/0.9.61/syslog4j-0.9.61.jar"))
 ;                                     ^ ^ ^
 ;                                     | | |

--- a/src/clojure/srcs/dnsresolvd.clj
+++ b/src/clojure/srcs/dnsresolvd.clj
@@ -25,6 +25,9 @@
             with-channel
             send!
         ]]
+        [clojure.data.json  :refer [
+            write-str
+        ]]
     )
 
     (:import [java.net InetAddress ])
@@ -149,39 +152,32 @@
 "<body>"                                                                                  (AUX/NEW-LINE)
 "<div>"      hostname (AUX/ONE-SPACE-STRING       ))
         (= fmt (AUX/PRM-FMT-JSON))
-            (str (AUX/CB1                         )
-                 (AUX/DAT-HOSTNAME-N              )
-                 (AUX/DQ1                         )
-                 hostname
-                 (AUX/DQ2                         ))
+            (hash-map (AUX/DAT-HOSTNAME-N         )
+             hostname)
     )]
 
     ; If lookup error occurred.
     (let [resp-buffer0 (cond
         (= addr (AUX/ERR-PREFIX)) (cond
             (= fmt (AUX/PRM-FMT-HTML))
-                (str resp-buffer- (AUX/ERR-PREFIX          )
-                                  (AUX/COLON-SPACE-SEP     )
-                                  (AUX/ERR-COULD-NOT-LOOKUP))
+                (str   resp-buffer- (AUX/ERR-PREFIX          )
+                                    (AUX/COLON-SPACE-SEP     )
+                                    (AUX/ERR-COULD-NOT-LOOKUP))
             (= fmt (AUX/PRM-FMT-JSON))
-                (str resp-buffer- (AUX/ERR-PREFIX          )
-                                  (AUX/DQ1                 )
-                                  (AUX/ERR-COULD-NOT-LOOKUP))
+                (assoc resp-buffer- (AUX/ERR-PREFIX          )
+                                    (AUX/ERR-COULD-NOT-LOOKUP))
         ) :else (cond
             (= fmt (AUX/PRM-FMT-HTML))
-                (str resp-buffer- addr
-                                  (AUX/ONE-SPACE-STRING    )
-                                  (AUX/DAT-VERSION-V       )
-                                  ver)
+                (str   resp-buffer-  addr
+                                    (AUX/ONE-SPACE-STRING    )
+                                    (AUX/DAT-VERSION-V       )
+                                     ver                     )
             (= fmt (AUX/PRM-FMT-JSON))
-                (str resp-buffer- (AUX/DAT-ADDRESS-N       )
-                                  (AUX/DQ1                 )
-                                  addr
-                                  (AUX/DQ2                 )
-                                  (AUX/DAT-VERSION-N       )
-                                  (AUX/DQ1                 )
-                                  (AUX/DAT-VERSION-V       )
-                                  ver)
+                (assoc resp-buffer- (AUX/DAT-ADDRESS-N       )
+                                     addr
+                                    (AUX/DAT-VERSION-N       )
+                                    (str (AUX/DAT-VERSION-V  )
+                                     ver                     ))
         )
     )]
 
@@ -191,7 +187,7 @@
                               "</body>" (AUX/NEW-LINE)
                               "</html>" (AUX/NEW-LINE))
         (= fmt (AUX/PRM-FMT-JSON))
-            (str resp-buffer0           (AUX/CB2     ))
+            (write-str resp-buffer0)
     )]
 
     ; Returning HTTP status code, response headers, and a body of the response.

--- a/src/clojure/srcs/dnsresolvh.clj
+++ b/src/clojure/srcs/dnsresolvh.clj
@@ -28,12 +28,6 @@
 (defmacro DIGITS           [] #"\d+")
 (defmacro PARAMS-SEPS      [] #"=|&")
 
-; JSON entities :-).
-(defmacro CB1 []   "{\"")
-(defmacro CB2 []   "\"}")
-(defmacro DQ1 [] "\":\"")
-(defmacro DQ2 [] "\",\"")
-
 ; Common error messages.
 (defmacro ERR-PREFIX                    [] "error"                        )
 (defmacro ERR-PORT-MUST-BE-POSITIVE-INT [](str ": <port_number> must be "


### PR DESCRIPTION
**Subj.** :point_up:
Tested and claimed to work well on **Arch Linux**.