### PR TITLE
Vertosphere/Java: Implement starting up the daemon with proper error checking and reporting during startup, but with dummy HTTP request handler and actually defunct for a while.

### DIFF
--- a/src/java/DnsResolvd.java
+++ b/src/java/DnsResolvd.java
@@ -13,6 +13,7 @@
  */
 
 import static dns_resolv.ControllerHelper.*;
+import        dns_resolv.DnsLookupController;
 
 import org.graylog2.syslog4j.impl.unix.UnixSyslog;
 import org.graylog2.syslog4j.impl.unix.UnixSyslogConfig;
@@ -20,24 +21,6 @@ import org.graylog2.syslog4j.              SyslogIF;
 
 /** The startup class of the daemon. */
 public class DnsResolvd {
-    /**
-     * Starts up the daemon.
-     *
-     * @param port_number The server port number to listen on.
-     * @param daemon_name The name of the daemon startup script.
-     * @param log         The system logger object instance.
-     *
-     * @return The server exit code when interrupted.
-     */
-    private static int startup(final int        port_number,
-                               final String     daemon_name,
-                               final UnixSyslog log) {
-
-        int ret = EXIT_SUCCESS;
-
-        return ret;
-    }
-
     /**
      * The daemon entry point.
      *
@@ -128,12 +111,10 @@ public class DnsResolvd {
         }
 
         // Starting up the daemon.
-        ret = startup(port_number, daemon_name, log);
+        new DnsLookupController().startup(port_number, daemon_name, log);
 
         // Making final cleanups.
         cleanups_fixate(log);
-
-        System.exit(ret);
     }
 }
 

--- a/src/java/dns_resolv/ControllerHelper.java
+++ b/src/java/dns_resolv/ControllerHelper.java
@@ -38,6 +38,12 @@ public class ControllerHelper {
     public static final String ERR_PORT_MUST_BE_POSITIVE_INT = ": <port_number> must be "
                                                              + "a positive integer value, "
                                                              + "in the range 1024-49151.";
+    public static final String ERR_CANNOT_START_SERVER       = ": FATAL: Cannot start server ";
+    public static final String ERR_SRV_UNKNOWN_REASON        = "for an unknown reason. "
+                                                             +  "Exiting...";
+    public static final String ERR_SRV_PORT_IS_IN_USE        = "due to the port requested "
+                                                             +  "is in use. Exiting...";
+    public static final String ERR_ADDR_ALREADY_IN_USE       = "Address already in use";
 
     // Print this error message when there are no any args passed.
     public static final String ERR_MUST_BE_ONE_TWO_ARGS_1 = ": There must be one or two args passed: ";
@@ -52,6 +58,10 @@ public class ControllerHelper {
 
     /** Constant: The maximum port number allowed. */
     public static final int MAX_PORT = 49151;
+
+    // Common notification messages.
+    public static final String MSG_SERVER_STARTED_1 = "Server started on port ";
+    public static final String MSG_SERVER_STARTED_2 = "=== Hit Ctrl+C to terminate it.";
 
     // Daemon name, version, and copyright banners.
     public static final String DMN_NAME        = "DNS Resolver Daemon (dnsresolvd)";

--- a/src/java/dnsresolvd
+++ b/src/java/dnsresolvd
@@ -24,10 +24,20 @@ else
     DEP_URL0=${DEP_PREF}org/graylog2/syslog4j/0.9.60/syslog4j-0.9.60.jar
 fi
 
-DEP_URL1=${DEP_PREF}net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar
+DU1=${DEP_PREF}net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar
+DU2=${DEP_PREF}io/vertx/vertx-core/3.5.0/vertx-core-3.5.0.jar
+DU3=${DEP_PREF}io/netty/netty-buffer/4.1.15.Final/netty-buffer-4.1.15.Final.jar
+DU4=${DEP_PREF}io/netty/netty-codec/4.1.15.Final/netty-codec-4.1.15.Final.jar
+DU5=${DEP_PREF}io/netty/netty-codec-dns/4.1.15.Final/netty-codec-dns-4.1.15.Final.jar
+DU6=${DEP_PREF}io/netty/netty-codec-http/4.1.15.Final/netty-codec-http-4.1.15.Final.jar
+DU7=${DEP_PREF}io/netty/netty-codec-http2/4.1.15.Final/netty-codec-http2-4.1.15.Final.jar
+DU8=${DEP_PREF}io/netty/netty-common/4.1.15.Final/netty-common-4.1.15.Final.jar
+DU9=${DEP_PREF}io/netty/netty-resolver/4.1.15.Final/netty-resolver-4.1.15.Final.jar
+D10=${DEP_PREF}io/netty/netty-resolver-dns/4.1.15.Final/netty-resolver-dns-4.1.15.Final.jar
+D11=${DEP_PREF}io/netty/netty-transport/4.1.15.Final/netty-transport-4.1.15.Final.jar
 
 # Invoking the startup class of the daemon.
-java -cp .:${DEP_URL0}:${DEP_URL1} DnsResolvd $0 $1 $2
+java -cp .:${DEP_URL0}:${DU1}:${DU2}:${DU3}:${DU4}:${DU5}:${DU6}:${DU7}:${DU8}:${DU9}:${D10}:${D11} DnsResolvd $0 $1 $2
 
 exit $?
 


### PR DESCRIPTION
- Adding **Vert.x** and **Netty** run-time dependencies.
- Adding constant literals for common error and notification messages.
- Implementing starting up the daemon with proper error checking and reporting during startup, but making HTTP request handler to be dummy and actually defunct for a while.