### PR TITLE
libsoup/C: Perform DNS lookup action for the given hostname.

### DIFF
--- a/src/c/libsoup/dnsresolvd.c
+++ b/src/c/libsoup/dnsresolvd.c
@@ -131,15 +131,12 @@ void _request_handler(      SoupServer        *dmn,
             fmt  = strcpy(fmt,      _PRM_FMT_JSON);
         }
     }
-
-    puts(hostname);
-    puts(fmt     );
     /* --------------------------------------------------------------------- */
     /* --- Parsing and validating request params - End --------------------- */
     /* --------------------------------------------------------------------- */
 
     /* Adding headers to the response. */
-    HDR_CONTENT_TYPE_V = add_response_headers(msg->response_headers, /*fmt*/_PRM_FMT_HTML);
+    HDR_CONTENT_TYPE_V = add_response_headers(msg->response_headers, fmt);
 
     soup_message_set_status  (msg, SOUP_STATUS_OK);
     soup_message_set_response(msg, HDR_CONTENT_TYPE_V, SOUP_MEMORY_COPY,

--- a/src/c/libsoup/dnsresolvd.c
+++ b/src/c/libsoup/dnsresolvd.c
@@ -135,6 +135,14 @@ void _request_handler(      SoupServer        *dmn,
     /* --- Parsing and validating request params - End --------------------- */
     /* --------------------------------------------------------------------- */
 
+    ADDR_VER *addr_ver;
+
+    addr_ver       = malloc(sizeof(ADDR_VER));
+    addr_ver->addr = malloc(INET6_ADDRSTRLEN);
+
+    /* Performing DNS lookup for the given hostname. */
+    addr_ver = dns_lookup(addr_ver, hostname);
+
     /* Adding headers to the response. */
     HDR_CONTENT_TYPE_V = add_response_headers(msg->response_headers, fmt);
 
@@ -143,6 +151,9 @@ void _request_handler(      SoupServer        *dmn,
                               resp_buffer, strlen(resp_buffer));
 
     free(HDR_CONTENT_TYPE_V);
+
+    free(addr_ver->addr);
+    free(addr_ver      );
 
     if ((qry == NULL) || (mtd == SOUP_METHOD_POST)) {
         free(fmt     );
@@ -302,6 +313,49 @@ int main(int argc, char *const *argv) {
     _cleanups_fixate(loop);
 
     return ret;
+}
+
+/**
+ * Performs DNS lookup action for the given hostname,
+ * i.e. (in this case) IP address retrieval by hostname.
+ *
+ * @param addr_ver The pointer to a structure containing IP address
+ *                 of the analyzing host/service and corresponding
+ *                 IP version (family) used to look up in DNS:
+ *                 <code>4</code> for IPv4-only hosts,
+ *                 <code>6</code> for IPv6-capable hosts.
+ * @param hostname The effective hostname to look up for.
+ *
+ * @return The <code>addr_ver</code> pointer is returned.
+ */
+ADDR_VER *dns_lookup(ADDR_VER *addr_ver, const char *hostname) {
+    struct hostent *hent;
+
+    hent = gethostbyname2(hostname, AF_INET);
+
+    /*
+     * If the host doesn't have the A record (IPv4),
+     * trying to find its AAAA record (IPv6).
+     */
+    if (hent == NULL) {
+        hent = gethostbyname2(hostname, AF_INET6);
+
+        if (hent == NULL) {
+            addr_ver->addr = strcpy(addr_ver->addr, _ERR_PREFIX);
+        } else {
+            addr_ver->addr = (char *) inet_ntop(AF_INET6, hent->h_addr_list[0],
+            addr_ver->addr,                        INET6_ADDRSTRLEN);
+
+            addr_ver->ver  = 6;
+        }
+    } else {
+        addr_ver->addr     = (char *) inet_ntop(AF_INET,  hent->h_addr_list[0],
+        addr_ver->addr,                            INET_ADDRSTRLEN);
+
+        addr_ver->ver      = 4;
+    }
+
+    return addr_ver;
 }
 
 /**

--- a/src/c/libsoup/dnsresolvd.h
+++ b/src/c/libsoup/dnsresolvd.h
@@ -26,6 +26,9 @@
 #include <glib.h>
 #include <glib-unix.h>
 
+#include <netdb.h>
+#include <arpa/inet.h>
+
 /* Helper constants. */
 #define _EMPTY_STRING       ""
 #define _ONE_SPACE_STRING  " "
@@ -35,6 +38,7 @@
 #define _PRINT_BANNER_OPT "-V"
 
 /* Common error messages. */
+#define _ERR_PREFIX                    "error"
 #define _ERR_PORT_MUST_BE_POSITIVE_INT "%s: <port_number> must be "           \
                                        "a positive integer value, "           \
                                        "in the range 1024-49151."
@@ -87,6 +91,21 @@
 /** Constant: The default hostname to look up for. */
 #define _DEF_HOSTNAME "openbsd.org"
 
+/**
+ * The structure to hold IP address of the analyzing host/service
+ * and corresponding IP version (family) used to look up in DNS:
+ * <code>4</code> for IPv4-only hosts,
+ * <code>6</code> for IPv6-capable hosts.
+ */
+typedef struct {
+    char           *addr;
+    unsigned short  ver;
+} ADDR_VER;
+
+/* Performs DNS lookup action for the given hostname. */
+ADDR_VER *dns_lookup(ADDR_VER *, const char *);
+
+/* Adds headers to the response. */
 char *add_response_headers(SoupMessageHeaders *, const char *);
 
 /* Helper protos. */


### PR DESCRIPTION
1. Getting rid of debug output and using effective request format selector.
2. Introducing a structure to hold IP address of the analyzing host/service and corresponding IP version (family) used to look up in DNS.
3. Adding and calling a function to perform DNS lookup action for the given hostname.