### PR TITLE
libmicrohttpd/C: Fix / adjust building the daemon under OpenBSD, Ubuntu Server, and Arch Linux.

### DIFF
--- a/src/c/libmicrohttpd/Makefile
+++ b/src/c/libmicrohttpd/Makefile
@@ -17,10 +17,9 @@ DEPS = $(EXEC).o
 
 # Specify flags and other vars here.
 # The following standards-compliance options work well with gcc 4.9.4
-# (OpenBSD 6.3, from packages):
+# (OpenBSD 6.5, from packages):
 #C_STD = c90 # Same as c89, same as -ansi .
-#C_STD = c99
-C_STD = c11
+C_STD = c99
 
 CFLAGS = -Wall -pedantic -std=$(C_STD) -O3 \
          -march=x86-64 -mtune=generic -pipe -fstack-protector-strong
@@ -36,9 +35,7 @@ LDLIBS = -lmicrohttpd
 # instead of implicitly using its system default gcc or clang.
 ifeq ($(shell uname), OpenBSD)
     CC = egcc
-else
-    CFLAGS  += -I/usr/local/include
-    LDFLAGS += -L/usr/local/lib
+    CFLAGS += -I/usr/local/include
 endif
 
 # Making the target.

--- a/src/c/libmicrohttpd/README.md
+++ b/src/c/libmicrohttpd/README.md
@@ -8,7 +8,7 @@
 ## Table of Contents
 
 * **[Building](#building)**
-  * [Building under OpenBSD/amd64 6.3](#building-under-openbsdamd64-63)
+  * [Building under OpenBSD/amd64 6.5](#building-under-openbsdamd64-65)
   * [Building under Ubuntu Server (Ubuntu 16.04.4 LTS x86-64)](#building-under-ubuntu-server-ubuntu-16044-lts-x86-64)
   * [Building under Arch Linux (kernel 4.15.10-1-ARCH x86-64)](#building-under-arch-linux-kernel-41510-1-arch-x86-64)
 * **[Running](#running)**
@@ -17,9 +17,9 @@
 
 This daemon implementation is known to be built and run successfully on OpenBSD, Ubuntu Server, and Arch Linux operating systems. So let's describe each build process sequentially.
 
-### Building under OpenBSD/amd64 6.3
+### Building under OpenBSD/amd64 6.5
 
-**Dependencies:** The only build and runtime dependency is the main library &ndash; **GNU libmicrohttpd**. ~~Since OpenBSD doesn't have it neither in packages nor in ports, it needs to build it from source.~~ In OpenBSD 6.3 it is prebuilt as a package &ndash; `libmicrohttpd-0.9.59.tgz` can be installed as usual: `$ sudo pkg_add -vvvvv libmicrohttpd`. Assuming the compiler GCC 4.9.4 is installed (preferably from packages: `$ sudo pkg_add -vvvvv gcc`)~~, the build process is straightforward, just as stated in the docs (download, unpack, configure, build, install):~~
+**Dependencies:** The only build and runtime dependency is the main library &ndash; **GNU libmicrohttpd**. ~~Since OpenBSD doesn't have it neither in packages nor in ports, it needs to build it from source.~~ In OpenBSD 6.5 it is prebuilt as a package &ndash; `libmicrohttpd-0.9.63.tgz` can be installed as usual: `$ sudo pkg_add -vvvvv libmicrohttpd`. Assuming the compiler GCC 4.9.4 is installed (preferably from packages: `$ sudo pkg_add -vvvvv gcc`)~~, the build process is straightforward, just as stated in the docs (download, unpack, configure, build, install):~~
 
 (Note that prior to this the **GNU make** package needs to be installed: `$ sudo pkg_add -vvvvv gmake`.)
 
@@ -29,15 +29,8 @@ Now the daemon might be built.
 $ cd src/c/libmicrohttpd
 $ gmake clean && gmake all
 rm -f dnsresolvd dnsresolvd.o
-egcc -Wall -pedantic -std=c11 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE   -c -o dnsresolvd.o dnsresolvd.c
+egcc -Wall -pedantic -std=c99 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE -I/usr/local/include   -c -o dnsresolvd.o dnsresolvd.c
 egcc   dnsresolvd.o  -lmicrohttpd -o dnsresolvd
-dnsresolvd.o: In function `_request_handler':
-dnsresolvd.c:(.text+0x754): warning: sprintf() is often misused, please use snprintf()
-dnsresolvd.c:(.text+0x3ed): warning: strcat() is almost always misused, please use strlcat()
-dnsresolvd.o: In function `_query_params_iterator':
-dnsresolvd.c:(.text+0xe4): warning: strcpy() is almost always misused, please use strlcpy()
-/usr/local/lib/gcc/x86_64-unknown-openbsd6.3/4.9.4/../../../libunistring.so.0.1: warning: stpcpy() is dangerous; do not use it
-/usr/local/lib/gcc/x86_64-unknown-openbsd6.3/4.9.4/../../../libgmp.so.10.0: warning: vsprintf() is often misused, please use vsnprintf()
 ```
 
 Once this is done, check it out... just for fun:))

--- a/src/c/libmicrohttpd/README.md
+++ b/src/c/libmicrohttpd/README.md
@@ -10,7 +10,7 @@
 * **[Building](#building)**
   * [Building under OpenBSD/amd64 6.5](#building-under-openbsdamd64-65)
   * [Building under Ubuntu Server (Ubuntu 16.04.6 LTS x86-64)](#building-under-ubuntu-server-ubuntu-16046-lts-x86-64)
-  * [Building under Arch Linux (kernel 4.15.10-1-ARCH x86-64)](#building-under-arch-linux-kernel-41510-1-arch-x86-64)
+  * [Building under Arch Linux (kernel 5.2.2-arch1-1-ARCH x86-64)](#building-under-arch-linux-kernel-522-arch1-1-arch-x86-64)
 * **[Running](#running)**
 
 ## Building
@@ -88,7 +88,7 @@ $ file dnsresolvd
 dnsresolvd: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=4598dfb6e593925e7abb04ffe32e1608534d868a, not stripped
 ```
 
-### Building under Arch Linux (kernel 4.15.10-1-ARCH x86-64)
+### Building under Arch Linux (kernel 5.2.2-arch1-1-ARCH x86-64)
 
 This is quite equal to the process of building the daemon under Ubuntu. Install the necessary dependencies:
 
@@ -98,7 +98,7 @@ $
 $ sudo pacman -Sy libmicrohttpd
 ```
 
-The version of the compiler GCC used is 7.3.0. The version of the library GNU libmicrohttpd used is 0.9.59.
+The version of the compiler GCC used is 9.1.0. The version of the library GNU libmicrohttpd used is 0.9.65.
 
 Now let's build the daemon.
 
@@ -106,18 +106,18 @@ Now let's build the daemon.
 $ cd src/c/libmicrohttpd
 $ make clean && make all
 rm -f dnsresolvd dnsresolvd.o
-cc -Wall -pedantic -std=c11 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE -I/usr/local/include   -c -o dnsresolvd.o dnsresolvd.c
-dnsresolvd.c: In function '_request_handler':
-dnsresolvd.c:371:27: warning: '%u' directive writing between 1 and 5 bytes into a region of size 2 [-Wformat-overflow=]
-         sprintf(ver_str, "%u", ver);
-                           ^~
+cc -Wall -pedantic -std=c99 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE   -c -o dnsresolvd.o dnsresolvd.c
+dnsresolvd.c: In function ‘_request_handler’:
+dnsresolvd.c:371:27: warning: ‘%u’ directive writing between 1 and 5 bytes into a region of size 2 [-Wformat-overflow=]
+  371 |         sprintf(ver_str, "%u", ver);
+      |                           ^~
 dnsresolvd.c:371:26: note: directive argument in the range [0, 65535]
-         sprintf(ver_str, "%u", ver);
-                          ^~~~
-dnsresolvd.c:371:9: note: 'sprintf' output between 2 and 6 bytes into a destination of size 2
-         sprintf(ver_str, "%u", ver);
-         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-cc -L/usr/local/lib  dnsresolvd.o  -lmicrohttpd -o dnsresolvd
+  371 |         sprintf(ver_str, "%u", ver);
+      |                          ^~~~
+dnsresolvd.c:371:9: note: ‘sprintf’ output between 2 and 6 bytes into a destination of size 2
+  371 |         sprintf(ver_str, "%u", ver);
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+cc   dnsresolvd.o  -lmicrohttpd -o dnsresolvd
 ```
 
 Once this is done, check it out... just for fun:))

--- a/src/c/libmicrohttpd/README.md
+++ b/src/c/libmicrohttpd/README.md
@@ -9,7 +9,7 @@
 
 * **[Building](#building)**
   * [Building under OpenBSD/amd64 6.5](#building-under-openbsdamd64-65)
-  * [Building under Ubuntu Server (Ubuntu 16.04.4 LTS x86-64)](#building-under-ubuntu-server-ubuntu-16044-lts-x86-64)
+  * [Building under Ubuntu Server (Ubuntu 16.04.6 LTS x86-64)](#building-under-ubuntu-server-ubuntu-16046-lts-x86-64)
   * [Building under Arch Linux (kernel 4.15.10-1-ARCH x86-64)](#building-under-arch-linux-kernel-41510-1-arch-x86-64)
 * **[Running](#running)**
 
@@ -50,7 +50,7 @@ $ file dnsresolvd
 dnsresolvd: ELF 64-bit LSB shared object, x86-64, version 1
 ```
 
-### Building under Ubuntu Server (Ubuntu 16.04.4 LTS x86-64)
+### Building under Ubuntu Server (Ubuntu 16.04.6 LTS x86-64)
 
 **Dependencies:** The only build and runtime dependency is the main library &ndash; **GNU libmicrohttpd**. It has to be installed from packages:
 
@@ -67,8 +67,8 @@ Now let's build the daemon.
 $ cd src/c/libmicrohttpd
 $ make clean && make all
 rm -f dnsresolvd dnsresolvd.o
-cc -Wall -pedantic -std=c11 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE -I/usr/local/include   -c -o dnsresolvd.o dnsresolvd.c
-cc -L/usr/local/lib  dnsresolvd.o  -lmicrohttpd -o dnsresolvd
+cc -Wall -pedantic -std=c99 -O3 -march=x86-64 -mtune=generic -pipe -fstack-protector-strong -D_DEFAULT_SOURCE   -c -o dnsresolvd.o dnsresolvd.c
+cc   dnsresolvd.o  -lmicrohttpd -o dnsresolvd
 ```
 
 Once this is done, check it out... just for fun:))
@@ -141,7 +141,7 @@ dnsresolvd: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically 
 
 To start up the daemon just specify a TCP port that should be used to listen on for incoming connections.
 
-OpenBSD/amd64 | Arch Linux:
+OpenBSD/amd64 | Ubuntu Server LTS x86-64 | Arch Linux:
 
 ```
 $ ./src/c/libmicrohttpd/dnsresolvd 8765


### PR DESCRIPTION
- **Fixing** building the daemon under **OpenBSD 6.5**.
- **Adjusting** building the daemon under **Ubuntu Server 16.04.6 LTS**.
- **Adjusting** building the daemon under **Arch Linux**.