### PR TITLE
libsoup/C: Make minor fixes in the code; search for include and lib build paths regardless of host OS.

### DIFF
--- a/src/c/libsoup/Makefile
+++ b/src/c/libsoup/Makefile
@@ -24,9 +24,10 @@ CFLAGS = -Wall -pedantic -std=$(C_STD) -O3 \
 # Telling the compiler to use additional set of features including those
 # from BSD and SVID, e.g. this macro explicitly declares the gethostbyname2()
 # function -- very important when building for Linux.
-#CFLAGS += -D_DEFAULT_SOURCE
+CFLAGS += -D_DEFAULT_SOURCE
 
-LDLIBS = -lsoup-2.4 -lglib-2.0 -ljson-glib-1.0
+CFLAGS += `pkg-config --cflags-only-I libsoup-2.4 json-glib-1.0`
+LDLIBS  = `pkg-config   --libs-only-l libsoup-2.4 json-glib-1.0`
 
 # If we're on OpenBSD, invoke its gcc from packages
 # instead of implicitly using its system default gcc or clang.
@@ -34,10 +35,7 @@ ifeq ($(shell uname), OpenBSD)
     CC = egcc
 else
     CC = tcc
-    CFLAGS += -I/usr/include/libsoup-2.4
-    CFLAGS += -I/usr/include/glib-2.0
-    CFLAGS += -I/usr/lib/glib-2.0/include
-    CFLAGS += -I/usr/include/json-glib-1.0
+#   CC = cc
 endif
 
 # Making the target.

--- a/src/c/libsoup/dnsresolvd.c
+++ b/src/c/libsoup/dnsresolvd.c
@@ -22,7 +22,7 @@ void _request_handler(      SoupServer        *dmn,
                             SoupClientContext *cln,
                             gpointer           usr) {
 
-    char *resp_buffer, ver[2], *ver_;
+    char *resp_buffer = NULL, ver[2], *ver_;
 
     char *mtd;
 
@@ -91,7 +91,7 @@ void _request_handler(      SoupServer        *dmn,
                        |            +--------------------------------------+
                        +-------------------------------------------------+ |
                                                                          | | */
-            while (param = strsep(&req_body_data, _AMPER)) {          /* | | */
+            while ((param = strsep(&req_body_data, _AMPER))) {        /* | | */
                 param_val_len = strlen(param) - 2;                    /* | |
                                                                          | | */
                        if (strncmp("h=", param, 2) == 0) { /* <----------+ | */
@@ -440,7 +440,7 @@ ADDR_VER *dns_lookup(ADDR_VER *addr_ver, const char *hostname) {
  *         function.
  */
 char *add_response_headers(SoupMessageHeaders *resp_hdrs, const char *fmt) {
-    char *HDR_CONTENT_TYPE_V;
+    char *HDR_CONTENT_TYPE_V = NULL;
 
     soup_message_headers_append(resp_hdrs, _HDR_CACHE_CONTROL_N,
                                            _HDR_CACHE_CONTROL_V);


### PR DESCRIPTION
- Making fixes **GCC**-proposed by its warnings like "suggest parentheses around assignment used as truth value **[-Wparentheses]**" and "XXX may be used uninitialized in this function **[-Wmaybe-uninitialized]**". (**[TCC](https://bellard.org/tcc)** doesn't emit anything on this.)
- Utilizing `pkg-config` to build _include_ and _lib_ search paths regardless of host OS.