### PR TITLE
libsoup/C: Correctly free up memory for request params; return HTTP 501 when applicable.

### DIFF
--- a/src/c/libsoup/dnsresolvd.c
+++ b/src/c/libsoup/dnsresolvd.c
@@ -115,8 +115,10 @@ void _request_handler(      SoupServer        *dmn,
 
             free(req_body_data_);
         }
-    } else {
-        return; /* <== In case of HTTP method not supported. */
+    } else { /* <== In case of HTTP method not supported. */
+        soup_message_set_status(msg, SOUP_STATUS_NOT_IMPLEMENTED);
+
+        return;
     }
 
     if ((strlen(hostname) == 0) || (strlen(hostname) > HOST_NAME_MAX)) {


### PR DESCRIPTION
- **Bugfix**: Correctly `free()` request parameters when dealing without using of `g_hash_table_lookup()`.
- Returning **HTTP 501 Not Implemented** for all methods except **GET** and **POST**, instead of defaultly returning **500**.