### PR TITLE
net/http/Go: Define a rudimentary default HTTP request handler and attach it to the server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,19 @@ script:
     ## Going one level up.
     - cd .. && ls -al
 
+    ## Building the DNS Resolver Daemon as the net/http/Go impl.
+    - cd go && ls -al
+            && make clean
+            && make clean
+            && ls -al
+            && make all
+            && make all
+            && ls -al
+            && echo
+
+    ## Returning to the previous working dir.
+    - cd - && ls -al
+
     ## Going one level up.
     - cd .. && ls -al
 

--- a/src/go/dnsresolvd.go
+++ b/src/go/dnsresolvd.go
@@ -111,6 +111,37 @@ func main() {
     log.Info(  _MSG_SERVER_STARTED_1 + port_number_str + _NEW_LINE +
                _MSG_SERVER_STARTED_2)
 
+    // Defining the default request handler.
+    _request_handler := func(resp http.ResponseWriter, req *http.Request) {
+        var resp_buffer string = _EMPTY_STRING
+
+        var hostname string = _DEF_HOSTNAME
+
+        resp_buffer = "<!DOCTYPE html>"                                                   + _NEW_LINE +
+"<html lang=\"en-US\" dir=\"ltr\">"                                                       + _NEW_LINE +
+"<head>"                                                                                  + _NEW_LINE +
+"<meta http-equiv=\"" + _HDR_CONTENT_TYPE_N      +                     "\"    content=\"" +
+                        _HDR_CONTENT_TYPE_V_HTML +                     "\"           />"  + _NEW_LINE +
+"<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"                            />"  + _NEW_LINE +
+"<meta       name=\"viewport\"        content=\"width=device-width,initial-scale=1\" />"  + _NEW_LINE +
+"<title>" + _DMN_NAME + "</title>"                                                        + _NEW_LINE +
+"</head>"                                                                                 + _NEW_LINE +
+"<body>"                                                                                  + _NEW_LINE +
+"<div>"   +  hostname + _ONE_SPACE_STRING;
+
+        resp_buffer += "</div>"  + _NEW_LINE +
+                       "</body>" + _NEW_LINE +
+                       "</html>" + _NEW_LINE
+
+        fmt.Fprintf(resp, resp_buffer)
+    }
+
+    /*
+     * Attaching HTTP request handlers to process incoming requests
+     * and producing the response.
+     */
+    http.HandleFunc("/", _request_handler)
+
     // Starting up the HTTP listener on <port_number>.
     e := http.ListenAndServe(_COLON + port_number_str, nil)
 

--- a/src/go/dnsresolvd.go
+++ b/src/go/dnsresolvd.go
@@ -127,7 +127,9 @@ func main() {
 "<title>" + _DMN_NAME + "</title>"                                                        + _NEW_LINE +
 "</head>"                                                                                 + _NEW_LINE +
 "<body>"                                                                                  + _NEW_LINE +
-"<div>"   +  hostname + _ONE_SPACE_STRING;
+"<div>"   +  hostname + _ONE_SPACE_STRING
+
+        resp_buffer += req.Method
 
         resp_buffer += "</div>"  + _NEW_LINE +
                        "</body>" + _NEW_LINE +

--- a/src/go/dnsresolvh.go
+++ b/src/go/dnsresolvh.go
@@ -66,6 +66,19 @@ const _MAX_PORT uint = 49151
 const _MSG_SERVER_STARTED_1 string = "Server started on port "
 const _MSG_SERVER_STARTED_2 string = "=== Hit Ctrl+C to terminate it."
 
+// HTTP response headers.
+const (
+    _HDR_CONTENT_TYPE_N      string = "Content-Type"
+    _HDR_CONTENT_TYPE_V_HTML string = "text/html; charset=UTF-8"
+    _HDR_CONTENT_TYPE_V_JSON string = "application/json"
+    _HDR_CACHE_CONTROL_N     string = "Cache-Control"
+    _HDR_CACHE_CONTROL_V     string = "no-cache, no-store, must-revalidate"
+    _HDR_EXPIRES_N           string = "Expires"
+    _HDR_EXPIRES_V           string = "Thu, 01 Dec 1994 16:00:00 GMT"
+    _HDR_PRAGMA_N            string = "Pragma"
+    _HDR_PRAGMA_V            string = "no-cache"
+)
+
 // Daemon name, version, and copyright banners.
 const (
     _DMN_NAME        string = "DNS Resolver Daemon (dnsresolvd)"
@@ -76,6 +89,9 @@ const (
     _DMN_COPYRIGHT__ string = "Copyright (C) 2017-2020"
     _DMN_AUTHOR      string = "Radislav Golubtsov <ragolubtsov@my.com>"
 )
+
+// Constant: The default hostname to look up for.
+const _DEF_HOSTNAME string = "openbsd.org"
 
 // Helper function. Makes final buffer cleanups, closes streams, etc.
 func _cleanups_fixate(log *syslog.Writer) {


### PR DESCRIPTION
- **Travis CI:** Adding a build compound command for the net/http/Go daemon's implementation.
- Defining a rudimentary default HTTP request handler and attaching it to the server.
- Printing out an HTTP method for debug purposes.